### PR TITLE
Testing order

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ $ yarn test
 
 This will run the entire test suite, both on server and client apps.
 
+If the api tests timeout, the issue might be with mongodb-memory-server. See https://github.com/nodkz/mongodb-memory-server/issues/204. Memory server explicitly depends on a version of MongoDB that depends on libcurl3, but Debian 10 and other OS's come with libcurl4 installed instead.
+
+To fix this, update node_modules/mongodb-memory-server-core/lib/util/MongoBinary.js#70.
+Set `exports.LATEST_VERSION = '4.3.3'` or a similar new version.
+
 #### End to End (e2e)
 
 For End-to-End testing, we have a full set of fixtures that test the overall functionality. Be advised that, for the time being, these tests are run ON THE SAME DATABASE as the default database (uwazi_developmet), so running these tests will DELETE any exisisting data and replace it with the testing fixtures. DO NOT RUN ON PRODUCTION ENVIRONMENTS!

--- a/app/api/relationships/specs/relationships.spec.js
+++ b/app/api/relationships/specs/relationships.spec.js
@@ -607,14 +607,11 @@ describe('relationships', () => {
     it('should call entities to update the metadata', async () => {
       await relationships.delete({ entity: 'bruceWayne' }, 'en');
 
-      expect(entities.updateMetdataFromRelationships).toHaveBeenCalledWith(
-        ['doc2', 'IHaveNoTemplate', 'thomasWayne', 'bruceWayne'],
-        'en'
-      );
-      expect(entities.updateMetdataFromRelationships).toHaveBeenCalledWith(
-        ['doc2', 'IHaveNoTemplate', 'thomasWayne', 'bruceWayne'],
-        'es'
-      );
+      const args = entities.updateMetdataFromRelationships.calls.allArgs();
+      args.forEach(arg => {
+        arg[0].forEach(doc => expect(['doc2', 'IHaveNoTemplate', 'thomasWayne', 'bruceWayne']).toContain(doc));
+        expect(['en', 'es']).toContain(arg[1]);
+      })
     });
 
     describe('when there is no condition', () => {

--- a/app/api/relationships/specs/relationships.spec.js
+++ b/app/api/relationships/specs/relationships.spec.js
@@ -32,6 +32,7 @@ import fixtures, {
 } from './fixtures';
 import relationships from '../relationships';
 import search from '../../search/search';
+import { exceptions } from 'winston';
 
 describe('relationships', () => {
   beforeEach(done => {
@@ -607,14 +608,22 @@ describe('relationships', () => {
     it('should call entities to update the metadata', async () => {
       await relationships.delete({ entity: 'bruceWayne' }, 'en');
 
+      expect(entities.updateMetdataFromRelationships).toHaveBeenCalledTimes(2);
+
+      const expectedDocs = ['doc2', 'IHaveNoTemplate', 'thomasWayne', 'bruceWayne'];
+      let expectedLanguages = ['en', 'es'];
       const args = entities.updateMetdataFromRelationships.calls.allArgs();
       args.forEach(arg => {
-        ['doc2', 'IHaveNoTemplate', 'thomasWayne', 'bruceWayne'].forEach(doc => {
-          expect(arg[0]).toContain(doc);
+        const [docs, languages] = arg;
+        expectedDocs.forEach(doc => {
+          expect(docs).toContain(doc);
         });
 
-        expect(['en', 'es']).toContain(arg[1]);
+        expect(expectedLanguages).toContain(languages);
+        expectedLanguages = expectedLanguages.filter(lang => lang != languages);
       })
+
+      expect(expectedLanguages).toEqual([]);
     });
 
     describe('when there is no condition', () => {

--- a/app/api/relationships/specs/relationships.spec.js
+++ b/app/api/relationships/specs/relationships.spec.js
@@ -609,7 +609,10 @@ describe('relationships', () => {
 
       const args = entities.updateMetdataFromRelationships.calls.allArgs();
       args.forEach(arg => {
-        arg[0].forEach(doc => expect(['doc2', 'IHaveNoTemplate', 'thomasWayne', 'bruceWayne']).toContain(doc));
+        ['doc2', 'IHaveNoTemplate', 'thomasWayne', 'bruceWayne'].forEach(doc => {
+          expect(arg[0]).toContain(doc);
+        });
+
         expect(['en', 'es']).toContain(arg[1]);
       })
     });

--- a/app/api/relationships/specs/relationships.spec.js
+++ b/app/api/relationships/specs/relationships.spec.js
@@ -32,7 +32,6 @@ import fixtures, {
 } from './fixtures';
 import relationships from '../relationships';
 import search from '../../search/search';
-import { exceptions } from 'winston';
 
 describe('relationships', () => {
   beforeEach(done => {
@@ -620,8 +619,8 @@ describe('relationships', () => {
         });
 
         expect(expectedLanguages).toContain(languages);
-        expectedLanguages = expectedLanguages.filter(lang => lang != languages);
-      })
+        expectedLanguages = expectedLanguages.filter(lang => lang !== languages);
+      });
 
       expect(expectedLanguages).toEqual([]);
     });


### PR DESCRIPTION
Adding a note to the READ.me to explain how to fix test mongodb timeouts and making a test order agnostic because different versions of the test mongodb do not perform the actions in the same order.

PR checklist:
- [X] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
