### PR TITLE
Fix staging failing

### DIFF
--- a/app/api/search/search.js
+++ b/app/api/search/search.js
@@ -240,7 +240,7 @@ const _denormalizeAggregations = async (aggregations, templates, dictionaries, l
       .filter(item => item);
 
     let denormalizedAggregation = Object.assign(aggregations[key], { buckets });
-    if (dictionary.values.find(v => v.values)) {
+    if (dictionary && dictionary.values.find(v => v.values)) {
       denormalizedAggregation = _formatDictionaryWithGroupsAggregation(
         denormalizedAggregation,
         dictionary


### PR DESCRIPTION
fixes #2959

Adds a check previous to accessing a dictionary when the property has an invalid configured thesauri as its content. This fixes the application failing.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
