### PR TITLE
Fix Nightmare E2E failing on GH workflows

### DIFF
--- a/.github/workflows/ci_e2e_suite1.yml
+++ b/.github/workflows/ci_e2e_suite1.yml
@@ -6,7 +6,7 @@ on:
       - master
       - development
       - release
-      - fix-github-pipelines
+      - fix-github-pipeline
   pull_request:
 
 jobs:

--- a/.github/workflows/ci_e2e_suite1.yml
+++ b/.github/workflows/ci_e2e_suite1.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   e2e_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     services:
       elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0-amd64

--- a/.github/workflows/ci_e2e_suite1.yml
+++ b/.github/workflows/ci_e2e_suite1.yml
@@ -6,6 +6,7 @@ on:
       - master
       - development
       - release
+      - fix-github-pipelines
   pull_request:
 
 jobs:

--- a/.github/workflows/ci_e2e_suite1.yml
+++ b/.github/workflows/ci_e2e_suite1.yml
@@ -6,7 +6,6 @@ on:
       - master
       - development
       - release
-      - fix-github-pipeline
   pull_request:
 
 jobs:

--- a/.github/workflows/ci_e2e_suite2.yml
+++ b/.github/workflows/ci_e2e_suite2.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   e2e_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     services:
       elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0-amd64

--- a/.github/workflows/ci_e2e_suite2.yml
+++ b/.github/workflows/ci_e2e_suite2.yml
@@ -6,7 +6,6 @@ on:
       - master
       - development
       - release
-      - fix-github-pipeline
   pull_request:
 
 jobs:

--- a/.github/workflows/ci_e2e_suite2.yml
+++ b/.github/workflows/ci_e2e_suite2.yml
@@ -6,6 +6,7 @@ on:
       - master
       - development
       - release
+      - fix-github-pipeline
   pull_request:
 
 jobs:


### PR DESCRIPTION
This PR downgrades the version of Ubuntu used for the Nightmare E2E jobs from `ubuntu-latest` (20.04) to `ubuntu-18.04` to make the suites work while we figure out the long term fix.
Follow up issue: #3514

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
