### PR TITLE
4380 - websocket's "Connection to the server lost" message sticks to the UI

### DIFF
--- a/app/react/App/sockets.js
+++ b/app/react/App/sockets.js
@@ -23,7 +23,7 @@ socket.on('disconnect', reason => {
   }
 });
 
-socket.on('reconnect', () => {
+socket.io.on('reconnect', () => {
   clearTimeout(disconnectTimeoutMessage);
   if (disconnectNotifyId) {
     store.dispatch(notificationActions.removeNotification(disconnectNotifyId));

--- a/app/react/App/specs/sockets.spec.js
+++ b/app/react/App/specs/sockets.spec.js
@@ -29,7 +29,7 @@ describe('sockets', () => {
       jasmine.clock().install();
       socket._callbacks.$disconnect[0]('transport close');
       jasmine.clock().tick(8000);
-      socket._callbacks.$reconnect[0]();
+      socket.io._callbacks.$reconnect[0]();
       jasmine.clock().tick(8000);
       expect(store.dispatch).toHaveBeenCalled();
       expect(store.dispatch.calls.allArgs()[5][0].notification.message).toEqual(
@@ -43,7 +43,7 @@ describe('sockets', () => {
         jasmine.clock().install();
 
         socket._callbacks.$disconnect[0]('transport close');
-        socket._callbacks.$reconnect[0]();
+        socket.io._callbacks.$reconnect[0]();
         jasmine.clock().tick(8000);
 
         expect(store.dispatch).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
fixes #4380

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
