### PR TITLE
Fixes erratic behavior on PDF when viewed on metadata extraction

### DIFF
--- a/app/react/MetadataExtraction/PDFSidePanel.tsx
+++ b/app/react/MetadataExtraction/PDFSidePanel.tsx
@@ -84,7 +84,9 @@ const PDFSidePanel = ({
             <div className="document-viewer">
               <SourceDocument
                 file={file}
-                onPDFLoaded={async () => scrollToPage(entitySuggestion.page || 1)}
+                onPageLoaded={async () => {
+                  await scrollToPage(entitySuggestion.page || 1);
+                }}
               />
             </div>
           </>

--- a/app/react/PDF/components/PDF.js
+++ b/app/react/PDF/components/PDF.js
@@ -40,6 +40,7 @@ class PDF extends Component {
       document.addEventListener('textlayerrendered', e => {
         this.pageLoaded(e.detail.pageNumber);
       });
+      document.addEventListener('textlayerrendered', this.props.onPageLoaded, { once: true });
     }
   }
 
@@ -189,6 +190,7 @@ class PDF extends Component {
 }
 
 PDF.defaultProps = {
+  onPageLoaded: () => {},
   filename: null,
   onPageChange: () => {},
   onPDFReady: () => {},
@@ -202,6 +204,7 @@ PDF.propTypes = {
   onPageChange: PropTypes.func,
   onTextSelection: PropTypes.func,
   onTextDeselection: PropTypes.func,
+  onPageLoaded: PropTypes.func,
   onPDFReady: PropTypes.func,
   file: PropTypes.string.isRequired,
   filename: PropTypes.string,

--- a/app/react/Viewer/components/Document.js
+++ b/app/react/Viewer/components/Document.js
@@ -90,6 +90,7 @@ export class Document extends Component {
       <PDF
         onPageChange={this.props.onPageChange}
         onPDFReady={this.onDocumentReady}
+        onPageLoaded={this.props.onPageLoaded}
         onLoad={this.pdfLoaded}
         file={`${APIURL}files/${file.filename}`}
         filename={file.filename}
@@ -129,6 +130,7 @@ export class Document extends Component {
 }
 
 Document.defaultProps = {
+  onPageLoaded: () => {},
   onDocumentReady: () => {},
   onPageChange: () => {},
   onClick: () => {},
@@ -151,6 +153,7 @@ Document.propTypes = {
   onPageChange: PropTypes.func,
   onDocumentReady: PropTypes.func,
   onPDFLoaded: PropTypes.func,
+  onPageLoaded: PropTypes.func,
   doc: PropTypes.object,
   file: PropTypes.object,
   selectedSnippet: PropTypes.instanceOf(Immutable.Map),


### PR DESCRIPTION
fixes #4436 The second issue `When the segment is not in the first page, it acts erratically and sometimes it doesn't allow to scroll back.`

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
