### PR TITLE
4548 formatter bugfixes

### DIFF
--- a/app/api/templates/reindex.js
+++ b/app/api/templates/reindex.js
@@ -1,3 +1,4 @@
+import { deepEquals } from 'shared/dataUtils';
 import templates from './templates';
 
 const SHOULD_NOT_TRIGGER_REINDEX = [
@@ -37,7 +38,10 @@ function compareTemplateProperties(updatedProperties, originalProperties) {
     }
 
     Object.keys(updatedProperty).forEach(originalKey => {
-      if (updatedProperty[originalKey] !== originalProperty[originalKey] && originalKey !== '_id') {
+      if (
+        originalKey !== '_id' &&
+        !deepEquals(updatedProperty[originalKey], originalProperty[originalKey])
+      ) {
         changedProps.push(originalKey);
       }
     });
@@ -74,6 +78,7 @@ function compareShallowProperties(updatedTemplate, originalTemplate, updatedKeys
       changedProperties.push(key);
     }
   });
+  console.log('changedProperties', changedProperties)
   return changedProperties;
 }
 

--- a/app/api/templates/reindex.js
+++ b/app/api/templates/reindex.js
@@ -78,7 +78,6 @@ function compareShallowProperties(updatedTemplate, originalTemplate, updatedKeys
       changedProperties.push(key);
     }
   });
-  console.log('changedProperties', changedProperties)
   return changedProperties;
 }
 

--- a/app/api/templates/specs/fixtures/fixtures.js
+++ b/app/api/templates/specs/fixtures/fixtures.js
@@ -9,7 +9,9 @@ const select4id = db.id();
 const swapTemplate = db.id();
 const relatedTo = db.id();
 const templateToBeInherited = db.id();
+const templateInheritingFromAnother = db.id();
 const propertyToBeInherited = db.id();
+const propertyToBeInherited2 = db.id();
 const thesauriId1 = db.id();
 const thesauriId2 = db.id();
 const templateWithExtractedMetadata = db.id();
@@ -123,21 +125,26 @@ export default {
       _id: templateToBeInherited,
       name: 'template to be inherited',
       commonProperties: [{ name: 'title', label: 'Title', type: 'text' }],
-      properties: [{ _id: propertyToBeInherited, name: 'inherit_me', type: 'text' }],
+      properties: [
+        { _id: propertyToBeInherited, name: 'inherit_me', type: 'text' },
+        { _id: propertyToBeInherited2, name: 'inherit_me_as_well', type: 'text' },
+      ],
       default: true,
     },
     {
+      _id: templateInheritingFromAnother,
       name: 'template inheriting from another',
-      commonProperties: [{ name: 'title', label: 'Title', type: 'text' }],
+      commonProperties: [{ _id: db.id(), name: 'title', label: 'Title', type: 'text' }],
       properties: [
         {
+          _id: db.id(),
           type: propertyTypes.relationship,
           name: 'inherit',
           label: 'Inherit',
-          relationtype: relatedTo,
-          content: templateToBeInherited,
+          relationType: relatedTo.toString(),
+          content: templateToBeInherited.toString(),
           inherit: {
-            property: propertyToBeInherited,
+            property: propertyToBeInherited.toString(),
             type: 'text',
           },
         },
@@ -244,7 +251,9 @@ export {
   templateWithContents,
   swapTemplate,
   templateToBeInherited,
+  templateInheritingFromAnother,
   propertyToBeInherited,
+  propertyToBeInherited2,
   relatedTo,
   thesauriId1,
   thesauriId2,

--- a/app/api/templates/specs/reindex.spec.js
+++ b/app/api/templates/specs/reindex.spec.js
@@ -129,8 +129,7 @@ describe('reindex', () => {
         expect(search.indexEntities).not.toHaveBeenCalled();
       });
 
-      // eslint-disable-next-line jest/no-focused-tests
-      fit('should not find structural changes on unchanged inherit', async () => {
+      it('should not find structural changes on unchanged inherit', async () => {
         const [template] = await templates.get({ _id: templateInheritingFromAnother });
         const reindex = await checkIfReindex(template);
 
@@ -183,8 +182,7 @@ describe('reindex', () => {
         expect(search.indexEntities).toHaveBeenCalled();
       });
 
-      // eslint-disable-next-line jest/no-focused-tests
-      fit('should find structural changes on changed inherit', async () => {
+      it('should find structural changes on changed inherit', async () => {
         const [template] = await templates.get({ _id: templateInheritingFromAnother });
         template.properties[0].inherit = {
           property: propertyToBeInherited2.toString(),

--- a/app/api/templates/utils.ts
+++ b/app/api/templates/utils.ts
@@ -51,6 +51,8 @@ const getInheritedProps = async (templates: TemplateSchema[]) => {
 };
 
 const denormalizeInheritedProperties = async (template: TemplateSchema) => {
+  if (template.synced) return template.properties;
+
   const inheritedProperties: { [k: string]: PropertySchema } = await getInheritedProps([template]);
 
   return template.properties?.map(prop => {

--- a/app/react/Metadata/helpers/formater.js
+++ b/app/react/Metadata/helpers/formater.js
@@ -134,7 +134,7 @@ export default {
     let relatedEntity;
     if (doc && doc.relations && doc.relations.length > 0) {
       const relation = doc.relations.find(e => e.entity === option.value);
-      relatedEntity = relation.entityData;
+      relatedEntity = relation?.entityData;
     }
 
     return { value, url, icon, parent, relatedEntity };

--- a/app/shared/dataUtils.ts
+++ b/app/shared/dataUtils.ts
@@ -1,25 +1,32 @@
+const arrayDeepEquals = (a: Array<any>, b: Array<any>): boolean => {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (!deepEquals(a[i], b[i])) return false;
+  }
+  return true;
+};
+
+const objectDeepEquals = (a: any, b: any): boolean => {
+  const aKeys = Object.keys(a).sort();
+  const bKeys = Object.keys(b).sort();
+  if (!arrayDeepEquals(aKeys, bKeys)) return false;
+
+  for (let i = 0; i < aKeys.length; i += 1) {
+    const key = aKeys[i];
+    if (!deepEquals(a[key], b[key])) return false;
+  }
+  return true;
+};
+
 const deepEquals = (a: any, b: any): boolean => {
   if (Array.isArray(a) || Array.isArray(b)) {
     if (Array.isArray(a) !== Array.isArray(b)) return false;
-    if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; i += 1) {
-      if (!deepEquals(a[i], b[i])) return false;
-    }
-    return true;
+    return arrayDeepEquals(a, b);
   }
 
   if (a && b && (typeof a === 'object' || typeof b === 'object')) {
     if ((typeof a === 'object') !== (typeof b === 'object')) return false;
-
-    const aKeys = Object.keys(a).sort();
-    const bKeys = Object.keys(b).sort();
-    if (!deepEquals(aKeys, bKeys)) return false;
-
-    for (let i = 0; i < aKeys.length; i += 1) {
-      const key = aKeys[i];
-      if (!deepEquals(a[key], b[key])) return false;
-    }
-    return true;
+    return objectDeepEquals(a, b);
   }
 
   return a === b;

--- a/app/shared/dataUtils.ts
+++ b/app/shared/dataUtils.ts
@@ -1,0 +1,28 @@
+const deepEquals = (a: any, b: any): boolean => {
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (Array.isArray(a) !== Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+      if (!deepEquals(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  if (a && b && (typeof a === 'object' || typeof b === 'object')) {
+    if ((typeof a === 'object') !== (typeof b === 'object')) return false;
+
+    const aKeys = Object.keys(a).sort();
+    const bKeys = Object.keys(b).sort();
+    if (!deepEquals(aKeys, bKeys)) return false;
+
+    for (let i = 0; i < aKeys.length; i += 1) {
+      const key = aKeys[i];
+      if (!deepEquals(a[key], b[key])) return false;
+    }
+    return true;
+  }
+
+  return a === b;
+};
+
+export { deepEquals };

--- a/app/shared/dataUtils.ts
+++ b/app/shared/dataUtils.ts
@@ -1,6 +1,7 @@
 const arrayDeepEquals = (a: Array<any>, b: Array<any>): boolean => {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i += 1) {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     if (!deepEquals(a[i], b[i])) return false;
   }
   return true;
@@ -13,6 +14,7 @@ const objectDeepEquals = (a: any, b: any): boolean => {
 
   for (let i = 0; i < aKeys.length; i += 1) {
     const key = aKeys[i];
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     if (!deepEquals(a[key], b[key])) return false;
   }
   return true;

--- a/app/shared/specs/dataUtils.spec.ts
+++ b/app/shared/specs/dataUtils.spec.ts
@@ -1,0 +1,292 @@
+import { deepEquals } from '../dataUtils';
+
+describe('deepEquals', () => {
+  it('should handle null or undefined', () => {
+    expect(deepEquals(null, 'data')).toBe(false);
+    expect(deepEquals(null, null)).toBe(true);
+    expect(deepEquals(undefined, 'data')).toBe(false);
+    expect(deepEquals(undefined, undefined)).toBe(true);
+    expect(deepEquals(undefined, null)).toBe(false);
+  });
+
+  it('should handle basic types', () => {
+    expect(deepEquals(true, false)).toBe(false);
+    expect(deepEquals(true, true)).toBe(true);
+    expect(deepEquals(0, 1)).toBe(false);
+    expect(deepEquals(0, 0)).toBe(true);
+    expect(deepEquals('string', 'other string')).toBe(false);
+    expect(deepEquals('string', 'string')).toBe(true);
+  });
+
+  it('should handle arrays', () => {
+    expect(deepEquals([], [])).toBe(true);
+    expect(deepEquals([0, 1], [])).toBe(false);
+    expect(deepEquals([], [0, 1])).toBe(false);
+    expect(deepEquals([0, 1, 2], [0, 1, 2])).toBe(true);
+    expect(deepEquals([0, 1, 2], [0, 1])).toBe(false);
+    expect(deepEquals([0, 1, 2], [0, 1, 'error'])).toBe(false);
+    expect(deepEquals([0, 'error', 2], [0, 1, 2])).toBe(false);
+    expect(deepEquals([0, 1, 2], null)).toBe(false);
+  });
+
+  it('should handle plain objects', () => {
+    expect(deepEquals({}, {})).toBe(true);
+    expect(deepEquals({ text: 'text', number: 1 }, {})).toBe(false);
+    expect(deepEquals({}, { text: 'text', number: 1 })).toBe(false);
+    expect(deepEquals({ text: 'text', number: 1 }, { number: 1, text: 'text' })).toBe(true);
+    expect(deepEquals({ text: 'text', number: 1 }, { text: 'text' })).toBe(false);
+    expect(deepEquals({ number: 1 }, { text: 'text', number: 1 })).toBe(false);
+    expect(deepEquals({ text: 'text', number: 1 }, { number: 'error', text: 1 })).toBe(false);
+    expect(deepEquals({ text: 'text', number: 0 }, { number: 'text', text: 1 })).toBe(false);
+    expect(deepEquals({ text: 'text', number: 1 }, null)).toBe(false);
+  });
+
+  describe('for complex cases', () => {
+    const base = {
+      rootText: 'root text',
+      rootNumber: 0,
+      rootArray: [
+        1,
+        [11, [111, 222, 333], 33],
+        {
+          inArrayText: 'in array text',
+          inArrayNumber: 1,
+          inArrayArray: [],
+        },
+      ],
+      rootObject: {
+        inObjectText: 'in object text',
+        inObjectNumber: 1,
+        inObjectArray: [0, 1, 2, []],
+      },
+    };
+    it('should find equality', () => {
+      expect(
+        deepEquals(base, {
+          rootText: 'root text',
+          rootNumber: 0,
+          rootArray: [
+            1,
+            [11, [111, 222, 333], 33],
+            {
+              inArrayText: 'in array text',
+              inArrayNumber: 1,
+              inArrayArray: [],
+            },
+          ],
+          rootObject: {
+            inObjectText: 'in object text',
+            inObjectNumber: 1,
+            inObjectArray: [0, 1, 2, []],
+          },
+        })
+      ).toBe(true);
+    });
+
+    it('should find missing values', () => {
+      expect(
+        deepEquals(base, {
+          rootText: 'root text',
+          // rootNumber: 0,
+          rootArray: [
+            1,
+            [11, [111, 222, 333], 33],
+            {
+              inArrayText: 'in array text',
+              inArrayNumber: 1,
+              inArrayArray: [],
+            },
+          ],
+          rootObject: {
+            inObjectText: 'in object text',
+            inObjectNumber: 1,
+            inObjectArray: [0, 1, 2, []],
+          },
+        })
+      ).toBe(false);
+      expect(
+        deepEquals(base, {
+          rootText: 'root text',
+          rootNumber: 0,
+          rootArray: [
+            1,
+            [11, [111, 222], 33], //missing 333
+            {
+              inArrayText: 'in array text',
+              inArrayNumber: 1,
+              inArrayArray: [],
+            },
+          ],
+          rootObject: {
+            inObjectText: 'in object text',
+            inObjectNumber: 1,
+            inObjectArray: [0, 1, 2, []],
+          },
+        })
+      ).toBe(false);
+      expect(
+        deepEquals(base, {
+          rootText: 'root text',
+          rootNumber: 0,
+          rootArray: [
+            1,
+            [11, [111, 222, 333], 33],
+            {
+              inArrayText: 'in array text',
+              inArrayNumber: 1,
+              //inArrayArray: [],
+            },
+          ],
+          rootObject: {
+            inObjectText: 'in object text',
+            inObjectNumber: 1,
+            inObjectArray: [0, 1, 2, []],
+          },
+        })
+      ).toBe(false);
+      expect(
+        deepEquals(base, {
+          rootText: 'root text',
+          rootNumber: 0,
+          rootArray: [
+            1,
+            [11, [111, 222, 333], 33],
+            {
+              inArrayText: 'in array text',
+              inArrayNumber: 1,
+              inArrayArray: [],
+            },
+          ],
+          rootObject: {
+            //inObjectText: 'in object text',
+            inObjectNumber: 1,
+            inObjectArray: [0, 1, 2, []],
+          },
+        })
+      ).toBe(false);
+      expect(
+        deepEquals(base, {
+          rootText: 'root text',
+          rootNumber: 0,
+          rootArray: [
+            1,
+            [11, [111, 222, 333], 33],
+            {
+              inArrayText: 'in array text',
+              inArrayNumber: 1,
+              inArrayArray: [],
+            },
+          ],
+          rootObject: {
+            inObjectText: 'in object text',
+            inObjectNumber: 1,
+            inObjectArray: [0, 1, 2, ['extra text']],
+          },
+        })
+      ).toBe(false);
+    });
+
+    it('should find different values', () => {
+      expect(
+        deepEquals(base, {
+          rootText: 'other text',
+          rootNumber: 0,
+          rootArray: [
+            1,
+            [11, [111, 222, 333], 33],
+            {
+              inArrayText: 'in array text',
+              inArrayNumber: 1,
+              inArrayArray: [],
+            },
+          ],
+          rootObject: {
+            inObjectText: 'in object text',
+            inObjectNumber: 1,
+            inObjectArray: [0, 1, 2, []],
+          },
+        })
+      ).toBe(false);
+      expect(
+        deepEquals(base, {
+          rootText: 'root text',
+          rootNumber: 0,
+          rootArray: [
+            99999,
+            [11, [111, 222, 333], 33],
+            {
+              inArrayText: 'in array text',
+              inArrayNumber: 1,
+              inArrayArray: [],
+            },
+          ],
+          rootObject: {
+            inObjectText: 'in object text',
+            inObjectNumber: 1,
+            inObjectArray: [0, 1, 2, []],
+          },
+        })
+      ).toBe(false);
+      expect(
+        deepEquals(base, {
+          rootText: 'root text',
+          rootNumber: 0,
+          rootArray: [
+            1,
+            [11, [111, 222, undefined], 33],
+            {
+              inArrayText: 'in array text',
+              inArrayNumber: 1,
+              inArrayArray: [],
+            },
+          ],
+          rootObject: {
+            inObjectText: 'in object text',
+            inObjectNumber: 1,
+            inObjectArray: [0, 1, 2, []],
+          },
+        })
+      ).toBe(false);
+      expect(
+        deepEquals(base, {
+          rootText: 'root text',
+          rootNumber: 0,
+          rootArray: [
+            1,
+            [11, [111, 222, 333], 33],
+            {
+              inArrayText: 'in array text',
+              inArrayNumber: 99999,
+              inArrayArray: [],
+            },
+          ],
+          rootObject: {
+            inObjectText: 'in object text',
+            inObjectNumber: 1,
+            inObjectArray: [0, 1, 2, []],
+          },
+        })
+      ).toBe(false);
+      expect(
+        deepEquals(base, {
+          rootText: 'root text',
+          rootNumber: 0,
+          rootArray: [
+            1,
+            [11, [111, 222, 333], 33],
+            {
+              inArrayText: 'in array text',
+              inArrayNumber: 1,
+              inArrayArray: [],
+            },
+          ],
+          rootObject: {
+            inObjectText: 'in object text',
+            inObjectNumber: 1,
+            inObjectArray: ['array with text instead of numbers'],
+          },
+        })
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
fixes #4547, #4548

This pr contains 3 fixes:

A single-character quick-fix for the formatter issue (#4548), allowing undefined values.

While debugging #4547, it was discovered that the template save still tries denormalize both the template and the related entities. The template denormalization has been turned off for synced templates (not for the whole instance, on a template-per-template basis.

The cause of the related entity denormalization was a bug, where the entity save always detected inherited properties as being changed.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
