### PR TITLE
4663 4664 metadata extraction e2e flakiness

### DIFF
--- a/e2e/suites/metadataExtraction.test.ts
+++ b/e2e/suites/metadataExtraction.test.ts
@@ -4,18 +4,17 @@ import { adminLogin, logout } from '../helpers/login';
 import proxyMock from '../helpers/proxyMock';
 import insertFixtures from '../helpers/insertFixtures';
 import disableTransitions from '../helpers/disableTransitions';
-import { waitForNavigation } from '../helpers/formActions';
 
 describe('Metadata Extraction', () => {
   beforeAll(async () => {
     await insertFixtures();
     await proxyMock();
+    await adminLogin();
     await disableTransitions();
   });
 
   it('should be hidden by a feature toggle.', async () => {
-    await adminLogin();
-    await waitForNavigation(expect(page).toClick('a', { text: 'Account settings' }));
+    await expect(page).toClick('a', { text: 'Account settings' })
     await expect(page).not.toMatchElement('a', { text: 'Metadata Extraction' });
   });
 

--- a/e2e/suites/metadataExtraction.test.ts
+++ b/e2e/suites/metadataExtraction.test.ts
@@ -14,7 +14,7 @@ describe('Metadata Extraction', () => {
   });
 
   it('should be hidden by a feature toggle.', async () => {
-    await expect(page).toClick('a', { text: 'Account settings' })
+    await expect(page).toClick('a', { text: 'Account settings' });
     await expect(page).not.toMatchElement('a', { text: 'Metadata Extraction' });
   });
 

--- a/e2e/suites/share-entities.test.ts
+++ b/e2e/suites/share-entities.test.ts
@@ -28,7 +28,7 @@ describe('Share entities', () => {
   const getEntitiesCollaborators = async () =>
     page.$$eval('.members-list tr .member-list-item', items => items.map(item => item.textContent));
 
-  const checkAccessOfPersons = (accesses: string[]) => {
+  const checkAccessOfPersons = async (accesses: string[]) => {
     accesses.map(async (access, index) => {
       await expect(page).toMatchElement(`.members-list tr:nth-child(${index + 1}) select`, {
         text: access,
@@ -114,7 +114,7 @@ describe('Share entities', () => {
       'Asesores legales',
       'editor',
     ]);
-    checkAccessOfPersons(['Can edit', 'Can see', 'Can edit']);
+    await checkAccessOfPersons(['Can edit', 'Can see', 'Can edit']);
     await expect(page).toClick('button', { text: 'Close' });
     await page.waitForSelector('.share-modal', { hidden: true });
   });
@@ -132,7 +132,7 @@ describe('Share entities', () => {
       'editor',
     ]);
 
-    checkAccessOfPersons(['Can edit', 'Mixed access', 'Mixed access']);
+    await checkAccessOfPersons(['Can edit', 'Mixed access', 'Mixed access']);
     await expect(page).toClick('button', { text: 'Close' });
     await page.waitForSelector('.share-modal', { hidden: true });
   });

--- a/e2e/suites/share-entities.test.ts
+++ b/e2e/suites/share-entities.test.ts
@@ -28,13 +28,14 @@ describe('Share entities', () => {
   const getEntitiesCollaborators = async () =>
     page.$$eval('.members-list tr .member-list-item', items => items.map(item => item.textContent));
 
-  const checkAccessOfPersons = async (accesses: string[]) => {
-    accesses.map(async (access, index) => {
-      await expect(page).toMatchElement(`.members-list tr:nth-child(${index + 1}) select`, {
-        text: access,
-      });
-    });
-  };
+  const checkAccessOfPersons = async (accesses: string[]) =>
+    Promise.all(
+      accesses.map(async (access, index) =>
+        expect(page).toMatchElement(`.members-list tr:nth-child(${index + 1}) select`, {
+          text: access,
+        })
+      )
+    );
 
   it('should create a collaborator in the shared User Group', async () => {
     await createUser({


### PR DESCRIPTION
fixes #4663, #4664 

The failures in this case might have been caused by an incorrect usage of our `disableTransitions` in the test running prior to these (`medatadataExtraction.test.ts`). 

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
