### PR TITLE
2275 - Enable HTML in templates' rich text fields

### DIFF
--- a/app/react/Metadata/components/Metadata.js
+++ b/app/react/Metadata/components/Metadata.js
@@ -24,7 +24,7 @@ export const showByType = (prop, compact, templateId) => {
       result = t('System', 'No property');
       break;
     case 'markdown':
-      result = <MarkdownViewer markdown={prop.value} />;
+      result = <MarkdownViewer html markdown={prop.value} />;
       break;
     case 'link':
       result = (

--- a/app/react/Metadata/components/specs/Metadata.spec.js
+++ b/app/react/Metadata/components/specs/Metadata.spec.js
@@ -1,8 +1,6 @@
-/* eslint-disable max-lines */
 import React from 'react';
-
 import { shallow } from 'enzyme';
-
+import MarkdownViewer from 'app/Markdown';
 import Metadata from '../Metadata';
 
 describe('Metadata', () => {
@@ -270,6 +268,44 @@ describe('Metadata', () => {
         },
       ];
       testSnapshot();
+    });
+  });
+
+  describe('markdown with HTML', () => {
+    it('should parse and use HTML tags in markdown fields', () => {
+      props.metadata = [
+        {
+          translateContext: 'oneTranslateContext',
+          name: 'label_array',
+          label: 'label array',
+          value: '<h1>A title in HTML</h1>',
+          type: 'markdown',
+        },
+      ];
+      const component = shallow(<Metadata {...props} />);
+      const markdown = component.find(MarkdownViewer);
+      expect(markdown.dive().props().children.type).toBe('h1');
+    });
+
+    it('should work with both mardown and HTML tags', () => {
+      props.metadata = [
+        {
+          translateContext: 'oneTranslateContext',
+          name: 'label_array',
+          label: 'label array',
+          value:
+            '## A subtitle in markdown\n<a href="https://somesite.com" target="_blank">A link</a>',
+          type: 'markdown',
+        },
+      ];
+      const component = shallow(<Metadata {...props} />);
+      const markdown = component.find(MarkdownViewer);
+      expect(markdown.dive().props().children[0].type).toBe('h2');
+      expect(markdown.dive().props().children[2].props.children.props).toEqual({
+        href: 'https://somesite.com',
+        target: '_blank',
+        children: 'A link',
+      });
     });
   });
 });

--- a/app/react/Metadata/components/specs/__snapshots__/Metadata.spec.js.snap
+++ b/app/react/Metadata/components/specs/__snapshots__/Metadata.spec.js.snap
@@ -62,7 +62,7 @@ exports[`Metadata should render a Markdown when the metadata is type mardown 1`]
     >
       <MarkdownViewer
         compact={false}
-        html={false}
+        html={true}
         lists={Array []}
         markdown="some markdown text"
       />


### PR DESCRIPTION
fixes #2275

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
