### PR TITLE
Subscribe to results on all uses of TaskManager

### DIFF
--- a/app/api/services/pdfsegmentation/PDFSegmentation.ts
+++ b/app/api/services/pdfsegmentation/PDFSegmentation.ts
@@ -32,6 +32,10 @@ class PDFSegmentation {
     });
   }
 
+  start() {
+    this.segmentationTaskManager.subscribeToResults();
+  }
+
   segmentOnePdf = async (
     file: { filename: string; _id: ObjectIdSchema },
     serviceUrl: string,

--- a/app/api/services/twitterintegration/TwitterIntegration.ts
+++ b/app/api/services/twitterintegration/TwitterIntegration.ts
@@ -45,6 +45,10 @@ class TwitterIntegration {
     });
   }
 
+  start() {
+    this.twitterTaskManager.subscribeToResults();
+  }
+
   getTwitterIntegrationSettings = async (): Promise<TwitterIntegrationSettingsType> => {
     const settingsValues = await settings.get({}, 'features');
     if (!settingsValues.features || !settingsValues.features.twitterIntegration) {

--- a/app/worker.ts
+++ b/app/worker.ts
@@ -31,6 +31,7 @@ DB.connect(config.DBHOST, dbAuth)
       new InformationExtraction().start();
 
       const segmentationConnector = new PDFSegmentation();
+      segmentationConnector.start();
       const segmentationRepeater = new DistributedLoop(
         'segmentation_repeat',
         segmentationConnector.segmentPdfs,
@@ -41,6 +42,7 @@ DB.connect(config.DBHOST, dbAuth)
       void segmentationRepeater.start();
 
       const twitterIntegration = new TwitterIntegration();
+      twitterIntegration.start();
       const twitterRepeater = new DistributedLoop(
         'twitter_repeat',
         twitterIntegration.addTweetsRequestsToQueue,


### PR DESCRIPTION
All classes using Taskmanager as a property now needs to call `start` method after instantiation.
