### PR TITLE
Upload to s3 asynchronous on file read for a better user experience

### DIFF
--- a/app/api/files/specs/storage_s3_upload_on_read.spec.ts
+++ b/app/api/files/specs/storage_s3_upload_on_read.spec.ts
@@ -4,6 +4,7 @@ import {
   DeleteObjectCommand,
   GetObjectCommand,
   NoSuchKey,
+  PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
 import waitForExpect from 'wait-for-expect';
@@ -42,13 +43,16 @@ describe('storage with s3 feature active', () => {
     await s3.send(
       new DeleteObjectCommand({ Bucket: 'uwazi-development', Key: 'uploads/test_s3_file.txt' })
     );
+    await s3.send(
+      new DeleteObjectCommand({ Bucket: 'uwazi-development', Key: 'uploads/already_uploaded.txt' })
+    );
     await s3.send(new DeleteObjectCommand({ Bucket: 'uwazi-development', Key: 'uploads/' }));
     await s3.send(new DeleteBucketCommand({ Bucket: 'uwazi-development' }));
     await s3.send(new DeleteBucketCommand({ Bucket: 'another-tenant' }));
   });
 
   describe('readableFile when s3 feature active', () => {
-    it('should store it on the s3 bucket and then return it as a readable', async () => {
+    beforeAll(async () => {
       testingTenants.mockCurrentTenant({
         name: 'uwazi_development',
         dbName: 'uwazi_development',
@@ -58,7 +62,9 @@ describe('storage with s3 feature active', () => {
         },
       });
       await setupTestUploadedPaths();
+    });
 
+    it('should store it on the s3 bucket and then return it as a readable', async () => {
       await expect((await fileContents('test_s3_file.txt', 'document')).toString()).toMatch(
         'test content'
       );
@@ -71,6 +77,19 @@ describe('storage with s3 feature active', () => {
           'test content'
         );
       });
+    });
+
+    it('should return a file from s3 when it is already there', async () => {
+      await s3.send(
+        new PutObjectCommand({
+          Bucket: 'uwazi-development',
+          Key: 'uploads/already_uploaded.txt',
+          Body: Buffer.from('already uploaded content', 'utf-8'),
+        })
+      );
+      await expect((await fileContents('already_uploaded.txt', 'document')).toString()).toMatch(
+        'already uploaded content'
+      );
     });
   });
 

--- a/app/api/files/specs/storage_s3_upload_on_read.spec.ts
+++ b/app/api/files/specs/storage_s3_upload_on_read.spec.ts
@@ -6,6 +6,7 @@ import {
   NoSuchKey,
   S3Client,
 } from '@aws-sdk/client-s3';
+import waitForExpect from 'wait-for-expect';
 import { config } from 'api/config';
 import { testingTenants } from 'api/utils/testingTenants';
 import { Readable } from 'stream';
@@ -62,12 +63,14 @@ describe('storage with s3 feature active', () => {
         'test content'
       );
 
-      const response = await s3.send(
-        new GetObjectCommand({ Bucket: 'uwazi-development', Key: 'uploads/test_s3_file.txt' })
-      );
-      await expect((await streamToString(response.Body as Readable)).toString()).toMatch(
-        'test content'
-      );
+      await waitForExpect(async () => {
+        const response = await s3.send(
+          new GetObjectCommand({ Bucket: 'uwazi-development', Key: 'uploads/test_s3_file.txt' })
+        );
+        await expect((await streamToString(response.Body as Readable)).toString()).toMatch(
+          'test content'
+        );
+      });
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uwazi",
-  "version": "1.78.0-rc2",
+  "version": "1.78.0-rc3",
   "description": "Uwazi is a free, open-source solution for organising, analysing and publishing your documents.",
   "keywords": [
     "react"


### PR DESCRIPTION
fixes waiting for file upload to s3 before serving the file to the client, file will be upload asynchronously and the file served from disk

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
