### PR TITLE
Stabilization: error accessing just-created supporting file

### DIFF
--- a/app/api/files/specs/routes.spec.ts
+++ b/app/api/files/specs/routes.spec.ts
@@ -280,7 +280,9 @@ describe('files routes', () => {
       expect(response.status).toBe(200);
       const [file]: FileType[] = await files.get({ originalname: 'test.txt' });
       expect(await fileExists(file.filename!, 'document')).toBe(true);
-      expect(errorLog.debug).toHaveBeenCalledWith(expect.stringContaining('Deprecation'));
+      expect(errorLog.debug).toHaveBeenCalledWith(
+        expect.stringMatching('[default](.*)Deprecation')
+      );
     });
   });
 
@@ -291,7 +293,7 @@ describe('files routes', () => {
         async filename => {
           const response = await request(app)
             .post(`/api/files/upload/${type}`)
-            .field('filename', filename)
+            .field('originalname', filename)
             .attach('file', path.join(__dirname, filename));
           expect(response.status).toBe(200);
           const [file]: FileType[] = await files.get({ originalname: filename, type });

--- a/app/api/files/uploadMiddleware.ts
+++ b/app/api/files/uploadMiddleware.ts
@@ -26,13 +26,15 @@ const move = async (req: Request, filePath: pathFunction) => {
 };
 
 const processOriginalFileName = (req: Request) => {
-  if (req.body.filename) {
-    return req.body.filename;
+  if (req.body.originalname) {
+    return req.body.originalname;
   }
 
   errorLog.debug(
-    // eslint-disable-next-line max-len
-    `[${tenants.current.name}] Deprecation warning: providing the filename in the multipart header is deprecated and will stop working in the future. Include a 'filename' field in the body instead.`
+    `[${
+      tenants.current().name
+      // eslint-disable-next-line max-len
+    }] Deprecation warning: providing the filename in the multipart header is deprecated and will stop working in the future. Include an 'originalname' field in the body instead.`
   );
 
   return req.file?.originalname;
@@ -81,7 +83,7 @@ const multipleUpload = async (req: Request, res: Response, next: NextFunction) =
  * accepts a single file and moves it to the path provided by path function
  * @param pathFunction is optional, when undefined the file will be stored on the os tmp default dir
  */
-const uploadMiddleware = (filePath?: pathFunction, storage?: StorageEngine) => {
+const uploadMiddleware = (filePath?: pathFunction, storage?: StorageEngine) =>
   // const s3 = new S3Client({
   //   apiVersion: 'latest',
   //   region: 'greenhost',
@@ -95,9 +97,7 @@ const uploadMiddleware = (filePath?: pathFunction, storage?: StorageEngine) => {
   //     cb(null, generateFileName(file));
   //   },
   // })
-  return singleUpload(filePath, storage);
-};
-
+  singleUpload(filePath, storage);
 /**
  * accepts multiple files and places them in req.files array
  * files will not be stored on disk and will be on a buffer on each element of the array.

--- a/app/react/Attachments/actions/actions.js
+++ b/app/react/Attachments/actions/actions.js
@@ -48,7 +48,7 @@ export function uploadAttachment(entity, file, storeKeys) {
       .set('Accept', 'application/json')
       .set('X-Requested-With', 'XMLHttpRequest')
       .field('entity', entity)
-      .field('filename', file.name)
+      .field('originalname', file.name)
       .attach('file', file)
       .on('progress', data => {
         dispatch({ type: types.ATTACHMENT_PROGRESS, entity, progress: Math.floor(data.percent) });

--- a/app/react/Attachments/actions/specs/actions.spec.js
+++ b/app/react/Attachments/actions/specs/actions.spec.js
@@ -70,7 +70,7 @@ describe('Attachments actions', () => {
 
       store.dispatch(actions.uploadAttachment('sharedId', file, { __reducerKey: 'storeKey' }));
       expect(mockUpload.field).toHaveBeenCalledWith('entity', 'sharedId');
-      expect(mockUpload.field).toHaveBeenCalledWith('filename', file.name);
+      expect(mockUpload.field).toHaveBeenCalledWith('originalname', file.name);
       expect(mockUpload.attach).toHaveBeenCalledWith('file', file);
 
       mockUpload.emit('progress', { percent: 55.1 });

--- a/app/react/Uploads/actions/specs/uploadsActions.spec.js
+++ b/app/react/Uploads/actions/specs/uploadsActions.spec.js
@@ -290,7 +290,7 @@ describe('uploadsActions', () => {
         const file = getMockFile();
 
         store.dispatch(actions.uploadCustom(file)).then(() => {
-          expect(mockUpload.field).toHaveBeenCalledWith('filename', file.name);
+          expect(mockUpload.field).toHaveBeenCalledWith('originalname', file.name);
           expect(mockUpload.attach).toHaveBeenCalledWith('file', file);
           expect(store.getActions()).toEqual(expectedActions);
           expect(superagent.post).toHaveBeenCalledWith(`${APIURL}files/upload/custom`);

--- a/app/react/Uploads/actions/specs/uploadsActions.spec.js
+++ b/app/react/Uploads/actions/specs/uploadsActions.spec.js
@@ -261,7 +261,7 @@ describe('uploadsActions', () => {
 
         store.dispatch(actions.uploadDocument('abc1', file));
         expect(mockUpload.field).toHaveBeenCalledWith('entity', 'abc1');
-        expect(mockUpload.field).toHaveBeenCalledWith('filename', file.name);
+        expect(mockUpload.field).toHaveBeenCalledWith('originalname', file.name);
         expect(mockUpload.attach).toHaveBeenCalledWith('file', file);
 
         emitProgressAndResponse(mockUpload, {

--- a/app/react/Uploads/actions/uploadsActions.js
+++ b/app/react/Uploads/actions/uploadsActions.js
@@ -92,7 +92,7 @@ export function upload(docId, file, endpoint = 'files/upload/document') {
         .set('Accept', 'application/json')
         .set('X-Requested-With', 'XMLHttpRequest')
         .field('entity', docId)
-        .field('filename', file.name)
+        .field('originalname', file.name)
         .attach('file', file)
         .on('progress', data => {
           dispatch({


### PR DESCRIPTION
This PR fixes an error bug preventing the access to supporting files after upload. Additionally fixes a non-critical bug that uses the wrong tenant name in the debug logs.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
