### PR TITLE
5006 - 'Upload PDF' button doesn't change the uploading status when changing entities

### DIFF
--- a/app/react/Metadata/components/UploadButton.js
+++ b/app/react/Metadata/components/UploadButton.js
@@ -30,7 +30,12 @@ class UploadButton extends Component {
   constructor(props, context) {
     super(props, context);
 
-    this.state = { processing: false, failed: false, completed: false };
+    this.state = {
+      processing: false,
+      failed: false,
+      completed: false,
+      entitySharedId: props.entitySharedId,
+    };
     this.conversionStart = this.conversionStart.bind(this);
     this.conversionFailed = this.conversionFailed.bind(this);
     this.documentProcessed = this.documentProcessed.bind(this);
@@ -47,6 +52,19 @@ class UploadButton extends Component {
     socket.removeListener('conversionFailed', this.conversionFailed);
     socket.removeListener('documentProcessed', this.documentProcessed);
     clearTimeout(this.timeout);
+  }
+
+  static getDerivedStateFromProps(newProps, state) {
+    if (newProps.entitySharedId !== state.entitySharedId) {
+      return {
+        processing: false,
+        failed: false,
+        completed: false,
+        entitySharedId: newProps.entitySharedId,
+      };
+    }
+
+    return null;
   }
 
   onChange(e) {

--- a/app/react/Metadata/components/specs/UploadButton.spec.js
+++ b/app/react/Metadata/components/specs/UploadButton.spec.js
@@ -86,6 +86,18 @@ describe('UploadButton', () => {
         expect(icon.length).toBe(1);
       });
     });
+
+    describe('when entity changes', () => {
+      it('should show the default status of the button instead of an error', () => {
+        render();
+        component.setState({ processing: false, failed: true, entitySharedId: 'sharedabc1' });
+        component.update();
+        expect(component.find(Icon).find('[icon="exclamation-triangle"]').length).toBe(1);
+        component.setState({ processing: false, failed: true, entitySharedId: 'sharedabc2' });
+        component.update();
+        expect(component.find(Icon).find('[icon="exclamation-triangle"]').length).toBe(0);
+      });
+    });
   });
 
   describe('onChange', () => {


### PR DESCRIPTION
fixes #5006

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
