### PR TITLE
fix warning react unique key in translate

### DIFF
--- a/app/react/I18N/components/Translate.js
+++ b/app/react/I18N/components/Translate.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { actions } from 'app/I18N';
@@ -48,10 +48,10 @@ class Translate extends Component {
         {lines.map((line, index) => {
           const parsedLine = parseMarkdownItalicMarker(line);
           return (
-            <>
+            <Fragment key={line}>
               {parsedLine}
               {index < lines.length - 1 && <br />}
-            </>
+            </Fragment>
           );
         })}
       </span>

--- a/app/react/I18N/components/specs/Translate.spec.js
+++ b/app/react/I18N/components/specs/Translate.spec.js
@@ -57,7 +57,7 @@ describe('Translate', () => {
   describe('markdown support', () => {
     it('should parse line break in multiline text', () => {
       component = shallow(
-        <Translate>
+        <Translate edit={props.edit}>
           {`this
       is
       multiline
@@ -71,7 +71,7 @@ describe('Translate', () => {
 
     it('should parse italic text in translation value', () => {
       component = shallow(
-        <Translate>
+        <Translate edit={props.edit}>
           {`this
       is
       *an italic*


### PR DESCRIPTION
fixes warning on iterating lines in `Translate` component