### PR TITLE
Geolocation field Remove cleanup when values are not valid.

### DIFF
--- a/app/react/Forms/components/Geolocation.js
+++ b/app/react/Forms/components/Geolocation.js
@@ -29,10 +29,11 @@ export default class Geolocation extends Component {
     this.setState({ currentLatitude: newValue.lat, currentLongitude: newValue.lon });
     const { onChange, value } = this.props;
 
-    if (!isCoordinateValid(newValue.lat) || !isCoordinateValid(newValue.lon)) {
+    if (!newValue.lat && !newValue.lon) {
       onChange(this.emptyValue);
       return;
     }
+
     const valueToSend = value.slice(1);
     valueToSend.unshift(newValue);
     onChange(valueToSend);

--- a/app/react/Forms/components/specs/Geolocation.spec.js
+++ b/app/react/Forms/components/specs/Geolocation.spec.js
@@ -9,6 +9,7 @@ describe('Geolocation', () => {
   let props;
 
   const render = () => {
+    // eslint-disable-next-line react/jsx-props-no-spreading
     component = shallow(<Geolocation {...props} />);
     instance = component.instance();
   };
@@ -35,12 +36,6 @@ describe('Geolocation', () => {
   });
 
   describe('when lat changes', () => {
-    it('with invalid coordinated should call onChange with empty value', () => {
-      const latInput = component.find('input').at(0);
-      latInput.simulate('change', { target: { value: '' } });
-      expect(props.onChange).toHaveBeenCalledWith([]);
-    });
-
     function expectOnChangeCallWhenInputSimulation(simulatedInput, expectedValue) {
       const latInput = component.find('input').at(0);
       latInput.simulate('change', { target: { value: simulatedInput } });
@@ -83,11 +78,6 @@ describe('Geolocation', () => {
         props.value[1],
       ]);
     });
-
-    it('should call onChange with empty value when invalid longitude', () => {
-      lonInput.simulate('change', { target: { value: '' } });
-      expect(props.onChange).toHaveBeenCalledWith([]);
-    });
   });
 
   describe('mapClick', () => {
@@ -118,20 +108,11 @@ describe('Geolocation', () => {
       expect(props.onChange).toHaveBeenCalledWith([]);
     }
 
-    describe('if lon is empty and lat is set to empty', () => {
-      it('should call onChange without a value', () => {
-        props.value[0].lon = '';
-        render();
-        testInputWillTriggerOnChangeWithoutValue(inputs => inputs.at(0));
-      });
-    });
-
-    describe('if lat is empty and lon is set to empty', () => {
-      it('should call onChange without a value', () => {
-        props.value[0].lat = '';
-        render();
-        testInputWillTriggerOnChangeWithoutValue(inputs => inputs.at(1));
-      });
+    it('should return an empty value', () => {
+      props.value[0].lon = '';
+      props.value[0].lat = '';
+      render();
+      testInputWillTriggerOnChangeWithoutValue(inputs => inputs.at(0));
     });
 
     describe('when they are no empty anymore', () => {


### PR DESCRIPTION
fixes #5130 

- Server validates this properly.
- Client validates this properly.
- Geolocation field was doing a strange cleanup of the values when one of them is not valid and sending an empy geolocation value, effectively hiding the error for the user, im pretty sure this cleanup had no other purpose, please double check !

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
