### PR TITLE
fix ubuntu version at 20.04 for e2e tests

### DIFF
--- a/.github/workflows/ci_e2e_puppeteer.yml
+++ b/.github/workflows/ci_e2e_puppeteer.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   e2e-puppeteer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
E2e tests were failing after the ubuntu-latest docker image was upgraded by their maintainers to 22. The reason is that the version of the mongo shell commands (mongo, mongorestore) we use are supported only until ubuntu-20.04. For us, this meant that the restore.sh script could not load in the fixtures due to those missing terminal commands. 
This pr fixes the issue by explicitly using ubuntu-20.04 instead of ubuntu-latest. A long-term option would be upgrading our mongo version.
