### PR TITLE
[Stabilization fix] - Errors in custom pages

### DIFF
--- a/app/react/App/App.js
+++ b/app/react/App/App.js
@@ -24,7 +24,7 @@ const App = ({ customParams }) => {
   const [confirmOptions, setConfirmOptions] = useState({});
   const location = useLocation();
   const params = useParams();
-  const sharedId = customParams?.sharedId || params.sharedId;
+  const sharedId = params.sharedId || customParams?.sharedId;
 
   const toggleMobileMenu = visible => {
     setShowMenu(visible);

--- a/app/react/Pages/components/PageViewer.js
+++ b/app/react/Pages/components/PageViewer.js
@@ -12,6 +12,7 @@ import { Icon } from 'UI';
 import { Translate } from 'app/I18N';
 import { ErrorFallback } from 'app/App/ErrorHandling/ErrorFallback';
 import { parseRenderingError } from 'app/App/ErrorHandling/ErrorUtils';
+import { NeedAuthorization } from 'app/Auth';
 import Script from './Script';
 
 const parseSSRError = error => {
@@ -48,14 +49,16 @@ class PageViewer extends Component {
 
   renderErrorWarning() {
     return (
-      <div className="alert alert-danger">
-        <Icon icon="exclamation-triangle" />
-        <Translate translationKey="custom page error warning">
-          There is an unexpected error on this custom page, it may not work properly. Please contact
-          an admin for details.
-        </Translate>
-        <Icon icon="times" onClick={() => this.removeCustomPageError()} />
-      </div>
+      <NeedAuthorization roles={['admin', 'editor', 'collaborator']}>
+        <div className="alert alert-danger">
+          <Icon icon="exclamation-triangle" />
+          <Translate translationKey="custom page error warning">
+            There is an unexpected error on this custom page, it may not work properly. Please
+            contact an admin for details.
+          </Translate>
+          <Icon icon="times" onClick={() => this.removeCustomPageError()} />
+        </div>
+      </NeedAuthorization>
     );
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uwazi",
-  "version": "1.107.0-rc3",
+  "version": "1.107.0-rc4",
   "description": "Uwazi is a free, open-source solution for organising, analysing and publishing your documents.",
   "keywords": [
     "react"


### PR DESCRIPTION
This is a fix to address two separate issues:

- Custom home page class names where not correctly set per page. When users used a custom home landing page, the landing page ID was always the one to be used compose the custom page class name, instead of using the actual page's ID.

- A warning is displayed in some custom pages about an error on the page. This happens inconsistently across instances and is not reproducible locally. The error itself is about a difference between the server side render and the client render. The proposed solution is to only display errors in the page for logged in users.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
