### PR TITLE
[Stabilization fix] - Use app class name only on pages and custom home page

### DIFF
--- a/app/react/App/App.js
+++ b/app/react/App/App.js
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Outlet, useLocation, useParams } from 'react-router-dom';
+import { Outlet, useLocation, useParams, useMatches } from 'react-router-dom';
 import Notifications from 'app/Notifications';
 import Cookiepopup from 'app/App/Cookiepopup';
 import { TranslateForm, t } from 'app/I18N';
@@ -25,6 +25,9 @@ const App = ({ customParams }) => {
   const location = useLocation();
   const params = useParams();
   const sharedId = params.sharedId || customParams?.sharedId;
+  const shouldAddAppClassName =
+    ['/', `/${params.lang}/`].includes(location.pathname) ||
+    location.pathname.match(/\/page\/.*\/.*/g);
 
   const toggleMobileMenu = visible => {
     setShowMenu(visible);
@@ -45,7 +48,7 @@ const App = ({ customParams }) => {
     navClass += ' is-active';
   }
 
-  const appClassName = sharedId ? `pageId_${sharedId}` : '';
+  const appClassName = shouldAddAppClassName && sharedId ? `pageId_${sharedId}` : '';
 
   return (
     <div id="app" className={appClassName}>

--- a/app/react/App/App.js
+++ b/app/react/App/App.js
@@ -27,7 +27,8 @@ const App = ({ customParams }) => {
   const sharedId = params.sharedId || customParams?.sharedId;
   const shouldAddAppClassName =
     ['/', `/${params.lang}/`].includes(location.pathname) ||
-    location.pathname.match(/\/page\/.*\/.*/g);
+    location.pathname.match(/\/page\/.*\/.*/g) ||
+    location.pathname.match(/\/entity\/.*/g);
 
   const toggleMobileMenu = visible => {
     setShowMenu(visible);

--- a/app/react/App/App.js
+++ b/app/react/App/App.js
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { Outlet, useLocation, useParams, useMatches } from 'react-router-dom';
+import { Outlet, useLocation, useParams } from 'react-router-dom';
 import Notifications from 'app/Notifications';
 import Cookiepopup from 'app/App/Cookiepopup';
 import { TranslateForm, t } from 'app/I18N';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uwazi",
-  "version": "1.108.0-rc2",
+  "version": "1.108.0-rc3",
   "description": "Uwazi is a free, open-source solution for organising, analysing and publishing your documents.",
   "keywords": [
     "react"


### PR DESCRIPTION
This pull request aims to fix errors occurring from always including a custom app page shared ID when rendering the app, even when in the settings or library. This happened after the react router upgrade, the global class name applied to the app should have been only used in pages, custom home pages, and entity views.

https://github.com/huridocs/uwazi/blob/027c6561b659a389178a626620503e55433de02a/app/react/App/App.js#L48

This line checks only if there's a valid shared id to add as a class name, but is not checking if the current page is actually a page and not the settings or library.  

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
