### PR TITLE
[STABILIZATION FIX] Topic classification route fix

### DIFF
--- a/app/react/Review/OneUpReview.tsx
+++ b/app/react/Review/OneUpReview.tsx
@@ -130,7 +130,9 @@ class OneUpReviewBase extends RouteHandler {
   }
 
   urlHasChanged(nextProps: any) {
-    return nextProps.location.query.q !== this.props.location.query.q;
+    const nextSearchParams = new URLSearchParams(nextProps.location.search);
+    const currentSearchParams = new URLSearchParams(this.props.location.search);
+    return nextSearchParams.get('q') !== currentSearchParams.get('q');
   }
 
   componentWillUnmount() {

--- a/app/react/Review/OneUpReview.tsx
+++ b/app/react/Review/OneUpReview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { actions as formActions } from 'react-redux-form';
-import { withContext } from 'app/componentWrappers';
+import { withContext, withRouter } from 'app/componentWrappers';
 import RouteHandler from 'app/App/RouteHandler';
 import { actions } from 'app/BasicReducer';
 import { Loader } from 'app/components/Elements/Loader';
@@ -26,7 +26,7 @@ import { IImmutable } from 'shared/types/Immutable';
 import { TemplateSchema } from 'shared/types/templateType';
 import { ThesaurusSchema } from 'shared/types/thesaurusType';
 
-export type OneUpReviewProps = {
+type OneUpReviewProps = {
   entity?: IImmutable<EntitySchema>;
   oneUpState?: IImmutable<OneUpState>;
   location?: { query: { q?: string } };
@@ -90,7 +90,7 @@ function buildInitialOneUpState(
   };
 }
 
-export class OneUpReviewBase extends RouteHandler {
+class OneUpReviewBase extends RouteHandler {
   static async requestState(requestParams: RequestParams, state: any) {
     const documentsRequest = requestParams.set({
       ...processQuery(requestParams.data, state),
@@ -172,10 +172,12 @@ interface OneUpReviewStore {
   };
 }
 
-export default connect(
-  (state: OneUpReviewStore) =>
-    ({
-      entity: state.entityView.entity,
-      oneUpState: state.oneUpReview.state,
-    } as OneUpReviewProps)
-)(withContext(OneUpReviewBase));
+const mapStateToProps = (state: OneUpReviewStore) =>
+  ({
+    entity: state.entityView.entity,
+    oneUpState: state.oneUpReview.state,
+  } as OneUpReviewProps);
+
+export type { OneUpReviewProps };
+export { OneUpReviewBase };
+export default connect(mapStateToProps)(withRouter(withContext(OneUpReviewBase)));

--- a/app/react/Thesauri/ThesaurusCockpit.tsx
+++ b/app/react/Thesauri/ThesaurusCockpit.tsx
@@ -11,6 +11,7 @@ import TemplatesAPI from 'app/Templates/TemplatesAPI';
 import { Notice } from 'app/Thesauri/Notice';
 import ThesauriAPI from 'app/Thesauri/ThesauriAPI';
 import { RequestParams } from 'app/utils/RequestParams';
+import { withRouter } from 'app/componentWrappers';
 import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -381,4 +382,4 @@ export default connect(mapStateToProps, {
   updateCockpitData,
   startTraining,
   toggleEnableClassification,
-})(ThesaurusCockpitBase);
+})(withRouter(ThesaurusCockpitBase));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uwazi",
-  "version": "1.113.0-rc4",
+  "version": "1.113.0-rc5",
   "description": "Uwazi is a free, open-source solution for organising, analysing and publishing your documents.",
   "keywords": [
     "react"


### PR DESCRIPTION
This stabilization fix mends the `dictionaries/cockpit/:id` route.