### PR TITLE
Fix for topic classification routes

### DIFF
--- a/app/react/Review/OneUpReview.tsx
+++ b/app/react/Review/OneUpReview.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { actions as formActions } from 'react-redux-form';
-import { withContext } from 'app/componentWrappers';
+import { withContext, withRouter } from 'app/componentWrappers';
 import RouteHandler from 'app/App/RouteHandler';
 import { actions } from 'app/BasicReducer';
 import { Loader } from 'app/components/Elements/Loader';
@@ -26,7 +26,7 @@ import { IImmutable } from 'shared/types/Immutable';
 import { TemplateSchema } from 'shared/types/templateType';
 import { ThesaurusSchema } from 'shared/types/thesaurusType';
 
-export type OneUpReviewProps = {
+type OneUpReviewProps = {
   entity?: IImmutable<EntitySchema>;
   oneUpState?: IImmutable<OneUpState>;
   location?: { query: { q?: string } };
@@ -90,7 +90,7 @@ function buildInitialOneUpState(
   };
 }
 
-export class OneUpReviewBase extends RouteHandler {
+class OneUpReviewBase extends RouteHandler {
   static async requestState(requestParams: RequestParams, state: any) {
     const documentsRequest = requestParams.set({
       ...processQuery(requestParams.data, state),
@@ -130,7 +130,9 @@ export class OneUpReviewBase extends RouteHandler {
   }
 
   urlHasChanged(nextProps: any) {
-    return nextProps.location.query.q !== this.props.location.query.q;
+    const nextSearchParams = new URLSearchParams(nextProps.location.search);
+    const currentSearchParams = new URLSearchParams(this.props.location.search);
+    return nextSearchParams.get('q') !== currentSearchParams.get('q');
   }
 
   componentWillUnmount() {
@@ -172,10 +174,12 @@ interface OneUpReviewStore {
   };
 }
 
-export default connect(
-  (state: OneUpReviewStore) =>
-    ({
-      entity: state.entityView.entity,
-      oneUpState: state.oneUpReview.state,
-    } as OneUpReviewProps)
-)(withContext(OneUpReviewBase));
+const mapStateToProps = (state: OneUpReviewStore) =>
+  ({
+    entity: state.entityView.entity,
+    oneUpState: state.oneUpReview.state,
+  } as OneUpReviewProps);
+
+export type { OneUpReviewProps };
+export { OneUpReviewBase };
+export default connect(mapStateToProps)(withRouter(withContext(OneUpReviewBase)));

--- a/app/react/Review/OneUpReview.tsx
+++ b/app/react/Review/OneUpReview.tsx
@@ -182,4 +182,5 @@ const mapStateToProps = (state: OneUpReviewStore) =>
 
 export type { OneUpReviewProps };
 export { OneUpReviewBase };
+//@ts-ignore
 export default connect(mapStateToProps)(withRouter(withContext(OneUpReviewBase)));

--- a/app/react/Review/OneUpReview.tsx
+++ b/app/react/Review/OneUpReview.tsx
@@ -29,7 +29,7 @@ import { ThesaurusSchema } from 'shared/types/thesaurusType';
 type OneUpReviewProps = {
   entity?: IImmutable<EntitySchema>;
   oneUpState?: IImmutable<OneUpState>;
-  location?: { query: { q?: string } };
+  location?: { search: { q?: string } };
   mainContext: { confirm: Function };
 };
 

--- a/app/react/Review/specs/OneUpReview.spec.tsx
+++ b/app/react/Review/specs/OneUpReview.spec.tsx
@@ -42,7 +42,7 @@ describe('Library', () => {
     props = {
       entity,
       oneUpState,
-      location: { query: { q: '(a:1)' } },
+      location: { search: { q: '(a:1)' } },
       mainContext: { confirm: jest.fn },
     };
     dispatchCallsOrder = [];
@@ -74,13 +74,13 @@ describe('Library', () => {
   describe('urlHasChanged', () => {
     it('return true when q has changed', () => {
       render();
-      const nextProps = { location: { query: { q: '(a:2)' } } };
+      const nextProps = { location: { search: { q: '(a:2)' } } };
       expect(component.instance().urlHasChanged(nextProps)).toBe(true);
     });
 
     it('should not update if "q" is the same', () => {
       render();
-      const nextProps = { location: { query: { q: '(a:1)' } } };
+      const nextProps = { location: { search: { q: '(a:1)' } } };
       expect(component.instance().urlHasChanged(nextProps)).toBe(false);
     });
   });

--- a/app/react/Thesauri/ThesaurusCockpit.tsx
+++ b/app/react/Thesauri/ThesaurusCockpit.tsx
@@ -11,6 +11,7 @@ import TemplatesAPI from 'app/Templates/TemplatesAPI';
 import { Notice } from 'app/Thesauri/Notice';
 import ThesauriAPI from 'app/Thesauri/ThesauriAPI';
 import { RequestParams } from 'app/utils/RequestParams';
+import { withRouter } from 'app/componentWrappers';
 import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
@@ -381,4 +382,4 @@ export default connect(mapStateToProps, {
   updateCockpitData,
   startTraining,
   toggleEnableClassification,
-})(ThesaurusCockpitBase);
+})(withRouter(ThesaurusCockpitBase));


### PR DESCRIPTION
This PR fixes missing code changes after the react router upgrade that enables routes to use search parameters and context.