### PR TITLE
React table extension of ColumnMeta with action and className properties 

### DIFF
--- a/app/react/V2/Components/UI/Table.tsx
+++ b/app/react/V2/Components/UI/Table.tsx
@@ -8,19 +8,14 @@ import {
   useReactTable,
   SortingState,
 } from '@tanstack/react-table';
-import {
-  TableProps,
-  CheckBoxHeader,
-  CheckBoxCell,
-  getIcon,
-  ColumnWithClassName,
-} from './TableTypes';
+import { TableProps, CheckBoxHeader, CheckBoxCell, getIcon } from './TableTypes';
 
 const applyForSelection = (
   withSelection: any,
   withOutSelection: any,
   enableSelection: boolean = false
 ) => (enableSelection ? withSelection : withOutSelection);
+
 // eslint-disable-next-line comma-spacing
 const Table = <T,>({
   columns,
@@ -80,7 +75,7 @@ const Table = <T,>({
   }, [onSelection, rowSelection, table]);
 
   return (
-    <div className="overflow-x-auto relative">
+    <div className="relative overflow-x-auto">
       <table className="w-full text-sm text-left">
         {title && (
           <caption className="p-5 text-lg font-semibold text-left text-gray-900 bg-white">
@@ -95,7 +90,7 @@ const Table = <T,>({
                 const isSortable = header.column.getCanSort();
                 const isSelect = header.column.id === 'checkbox-select';
                 const headerClassName = `${isSelect ? 'px-2' : 'px-6'} py-3 ${
-                  (header.column.columnDef as ColumnWithClassName<T>).className || ''
+                  header.column.columnDef.meta?.className || ''
                 }`;
 
                 return (

--- a/app/react/V2/Components/UI/TableTypes.tsx
+++ b/app/react/V2/Components/UI/TableTypes.tsx
@@ -1,27 +1,12 @@
 /* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable react/no-multi-comp */
 import React, { Dispatch, SetStateAction } from 'react';
-import {
-  ColumnDef,
-  CellContext,
-  Column,
-  TableState,
-  Row,
-  Table as TableDef,
-} from '@tanstack/react-table';
+import { ColumnDef, TableState, Row, Table as TableDef } from '@tanstack/react-table';
 import { ChevronUpDownIcon, ChevronUpIcon, ChevronDownIcon } from '@heroicons/react/20/solid';
 import { IndeterminateCheckbox } from './IndeterminateCheckbox';
 
-type ColumnWithClassName<T> = ColumnDef<T, any> & {
-  className?: string;
-};
-
-type CellContextWithMeta<T, U> = CellContext<T, U> & {
-  column: Column<T> & { columnDef: ColumnWithClassName<T> };
-};
-
 interface TableProps<T> {
-  columns: ColumnWithClassName<T>[];
+  columns: ColumnDef<T, any>[];
   data: T[];
   title?: string | React.ReactNode;
   initialState?: Partial<TableState>;
@@ -64,5 +49,5 @@ const CheckBoxCell = <T,>({ row }: { row: Row<T> }) => (
   />
 );
 
-export type { TableProps, ColumnWithClassName, CellContextWithMeta };
+export type { TableProps };
 export { CheckBoxHeader, CheckBoxCell, getIcon };

--- a/app/react/V2/Routes/Settings/Languages/LanguagesList.tsx
+++ b/app/react/V2/Routes/Settings/Languages/LanguagesList.tsx
@@ -119,41 +119,30 @@ const LanguagesList = () => {
   };
   const columnHelper = createColumnHelper<LanguageSchema>();
   const columns = [
-    {
-      ...columnHelper.accessor('label', {
-        id: 'label',
-        header: LabelHeader,
-        cell: LanguageLabel,
-      }),
-      className: 'w-9/12',
-    },
-    {
-      ...columnHelper.accessor('default', {
-        header: DefaultHeader,
-        cell: DefaultButton,
-        enableSorting: false,
-        meta: { action: setDefaultLanguage },
-      }),
-      className: 'text-center w-1/12',
-    },
-    {
-      ...columnHelper.accessor('key', {
-        header: ResetHeader,
-        cell: ResetButton,
-        enableSorting: false,
-        meta: { action: resetModal },
-      }),
-      className: 'text-center w-1/12',
-    },
-    {
-      ...columnHelper.accessor('_id', {
-        header: UninstallHeader,
-        cell: UninstallButton,
-        enableSorting: false,
-        meta: { action: uninstallModal },
-      }),
-      className: 'text-center w-1/12',
-    },
+    columnHelper.accessor('label', {
+      id: 'label',
+      header: LabelHeader,
+      cell: LanguageLabel,
+      meta: { className: 'w-9/12' },
+    }),
+    columnHelper.accessor('default', {
+      header: DefaultHeader,
+      cell: DefaultButton,
+      enableSorting: false,
+      meta: { action: setDefaultLanguage, className: 'text-center w-1/12' },
+    }),
+    columnHelper.accessor('key', {
+      header: ResetHeader,
+      cell: ResetButton,
+      enableSorting: false,
+      meta: { action: resetModal, className: 'text-center w-1/12' },
+    }),
+    columnHelper.accessor('_id', {
+      header: UninstallHeader,
+      cell: UninstallButton,
+      enableSorting: false,
+      meta: { action: uninstallModal, className: 'text-center w-1/12' },
+    }),
   ];
 
   return (

--- a/app/react/V2/Routes/Settings/Languages/components/TableComponents.tsx
+++ b/app/react/V2/Routes/Settings/Languages/components/TableComponents.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { StarIcon } from '@heroicons/react/20/solid';
 import { Translate } from 'app/I18N';
 import { Button } from 'V2/Components/UI/Button';
+import { CellContext } from '@tanstack/react-table';
+import { LanguageSchema } from 'shared/types/commonTypes';
 
-const DefaultButton = ({ cell, column }: any) => (
+const DefaultButton = ({ cell, column }: CellContext<LanguageSchema, boolean>) => (
   <Button
     styling={cell.row.original.default ? 'solid' : 'light'}
-    onClick={async () => column.columnDef.meta?.action(cell.row)}
+    onClick={async () => column.columnDef.meta?.action?.(cell.row)}
     className="leading-4"
   >
     <Translate className="sr-only">Default</Translate>
@@ -21,11 +23,11 @@ const DefaultButton = ({ cell, column }: any) => (
   </Button>
 );
 
-const UninstallButton = ({ cell, column }: any) =>
+const UninstallButton = ({ cell, column }: CellContext<LanguageSchema, string>) =>
   !cell.row.original.default ? (
     <Button
       styling="outline"
-      onClick={() => column.columnDef.meta?.action(cell.row)}
+      onClick={() => column.columnDef.meta?.action?.(cell.row)}
       className="leading-4"
     >
       <Translate>Uninstall</Translate>
@@ -34,11 +36,11 @@ const UninstallButton = ({ cell, column }: any) =>
     <> </>
   );
 
-const ResetButton = ({ cell, column }: any) =>
+const ResetButton = ({ cell, column }: CellContext<LanguageSchema, string>) =>
   cell.row.original.translationAvailable ? (
     <Button
       styling="outline"
-      onClick={() => column.columnDef.meta?.action(cell.row)}
+      onClick={() => column.columnDef.meta?.action?.(cell.row)}
       className="leading-4"
     >
       <Translate>Reset</Translate>

--- a/app/react/V2/Routes/Settings/Translations/TranslationsList.tsx
+++ b/app/react/V2/Routes/Settings/Translations/TranslationsList.tsx
@@ -45,27 +45,21 @@ const TranslationsList = () => {
   const columnHelper = createColumnHelper<ClientTranslationContextSchema>();
 
   const columns = [
-    {
-      ...columnHelper.accessor('label', {
-        header: LabelHeader,
-      }),
-      className: 'w-1/3',
-    },
-    {
-      ...columnHelper.accessor('type', {
-        header: TypeHeader,
-        cell: ContextPill,
-      }),
-      className: 'w-2/3',
-    },
-    {
-      ...columnHelper.accessor('id', {
-        header: ActionHeader,
-        cell: RenderButton,
-        enableSorting: false,
-      }),
-      className: 'text-center w-0',
-    },
+    columnHelper.accessor('label', {
+      header: LabelHeader,
+      meta: { className: 'w-1/3' },
+    }),
+    columnHelper.accessor('type', {
+      header: TypeHeader,
+      cell: ContextPill,
+      meta: { className: 'w-2/3' },
+    }),
+    columnHelper.accessor('id', {
+      header: ActionHeader,
+      cell: RenderButton,
+      enableSorting: false,
+      meta: { className: 'text-center w-0' },
+    }),
   ];
 
   return (

--- a/app/react/V2/Routes/Settings/Translations/components/TableComponents.tsx
+++ b/app/react/V2/Routes/Settings/Translations/components/TableComponents.tsx
@@ -82,15 +82,12 @@ const TranslationsTables = ({
       cell: LanguagePill,
       enableSorting: false,
     }),
-
-    {
-      ...columnHelper.accessor('fieldKey', {
-        header: FieldKeyHeader,
-        cell: memoizedInput,
-        enableSorting: false,
-      }),
-      className: 'w-full',
-    },
+    columnHelper.accessor('fieldKey', {
+      header: FieldKeyHeader,
+      cell: memoizedInput,
+      enableSorting: false,
+      meta: { className: 'w-full' },
+    }),
   ];
 
   return (

--- a/app/react/stories/Table.stories.tsx
+++ b/app/react/stories/Table.stories.tsx
@@ -91,10 +91,11 @@ const Basic: Story = {
     columns: [
       columnHelper.accessor('title', { header: 'Title', id: 'title' }),
       columnHelper.accessor('description', { header: 'Description' }),
-      {
-        ...columnHelper.accessor('created', { header: 'Date added', cell: CustomCell }),
-        className: 'something',
-      },
+      columnHelper.accessor('created', {
+        header: 'Date added',
+        cell: CustomCell,
+        meta: { className: 'something' },
+      }),
     ],
     data: [
       { title: 'Entity 2', created: 2, description: 'Short text' },
@@ -127,22 +128,23 @@ const WithActions: Story = {
     ...Basic.args,
     columns: [
       columnHelper.accessor('title', { id: 'title', header: 'Title' }),
-      {
-        ...columnHelper.accessor('created', { id: 'created', header: 'Date added' }),
-        className: 'w-1/3',
-      },
-      {
-        ...columnHelper.accessor('description', {
-          id: 'description',
-          header: 'Description',
-          enableSorting: false,
-        }),
-        className: 'w-1/3 bg-red-500 text-white',
-      },
-      {
-        ...columnHelper.display({ id: 'action', header: 'Actions', cell: ActionsCell }),
-        className: 'text-center',
-      },
+      columnHelper.accessor('created', {
+        id: 'created',
+        header: 'Date added',
+        meta: { className: 'w-1/3' },
+      }),
+      columnHelper.accessor('description', {
+        id: 'description',
+        header: 'Description',
+        enableSorting: false,
+        meta: { className: 'w-1/3 bg-red-500 text-white' },
+      }),
+      columnHelper.display({
+        id: 'action',
+        header: 'Actions',
+        cell: ActionsCell,
+        meta: { className: 'text-center' },
+      }),
     ],
   },
 };

--- a/app/shared/types/react-table-config.d.ts
+++ b/app/shared/types/react-table-config.d.ts
@@ -30,6 +30,14 @@ interface CustomColumn {
   className?: string;
 }
 
+declare module '@tanstack/table-core' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    action?: Function;
+    className?: string;
+  }
+}
+
 declare module 'react-table' {
   export interface Hooks<D extends object = {}>
     extends UseExpandedHooks<D>,

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "types": ["cypress", "cypress-plugin-snapshots", "webpack-env"],
   },
-  "include": ["./**/*", "./**/*.d.ts", "../app/react/V2/**/*.cy.tsx"],
+  "include": ["./**/*", "./**/*.d.ts", "../app/react/V2/**/*.cy.tsx", "../app/shared/types/react-table-config.d.ts"],
   "exclude": []
 }


### PR DESCRIPTION
React table provides a mechanism to extend the metadata of a column, this PR adds action and className definitions

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
