### PR TITLE
Fix users and groups table visual error

### DIFF
--- a/app/react/V2/Routes/Settings/Users/components/TableComponents.tsx
+++ b/app/react/V2/Routes/Settings/Users/components/TableComponents.tsx
@@ -44,7 +44,7 @@ const RolePill = ({ cell }: CellContext<ClientUserSchema, ClientUserSchema['role
 const MembersPill = ({
   cell,
 }: CellContext<ClientUserGroupSchema, ClientUserGroupSchema['members']>) => (
-  <div className="flex gap-1">
+  <div className="flex flex-wrap gap-2">
     {cell.getValue().map(member => (
       <div key={member.username}>
         <Pill color="gray">{member.username}</Pill>
@@ -54,7 +54,7 @@ const MembersPill = ({
 );
 
 const GroupsPill = ({ cell }: CellContext<ClientUserSchema, ClientUserSchema['groups']>) => (
-  <div className="flex gap-1">
+  <div className="flex flex-wrap gap-2">
     {cell.getValue()?.map(group => (
       <div key={cell.id + group._id}>
         <Pill color="gray" className="whitespace-nowrap">


### PR DESCRIPTION
This PR addresses a visual issue in the users and groups table, where if there were too many users or groups pills, the table would increase in size:

![image](https://github.com/huridocs/uwazi/assets/71732018/822450ee-2d3b-4393-abc2-9edbdd9ff11d)

Now it will wrap:
![image](https://github.com/huridocs/uwazi/assets/71732018/91387fbe-a0c1-41ba-a331-3ae21a9b7d9e)
