### PR TITLE
Fix Node18 fetch conflict 

### DIFF
--- a/app/react/entry-server.tsx
+++ b/app/react/entry-server.tsx
@@ -246,7 +246,10 @@ const resetTranslations = () => {
 const EntryServer = async (req: ExpressRequest, res: Response) => {
   RouteHandler.renderedFromServer = true;
   const [settings, assets] = await Promise.all([settingsApi.get(), getAssets()]);
-  const routes = getRoutes(settings, req.user && req.user._id, req.headers);
+  //https://github.com/trpc/trpc/issues/1811#issuecomment-1242222057
+  //for Node18 we have to remove the connection header
+  const { connection, ...headers } = req.headers;
+  const routes = getRoutes(settings, req.user && req.user._id, headers);
   const matched = matchRoutes(routes, req.path);
   const language = matched ? matched[0].params.lang : req.language;
 

--- a/app/react/utils/api.js
+++ b/app/react/utils/api.js
@@ -130,12 +130,15 @@ const handleError = (e, endpoint) => {
 };
 
 const _request = (url, req, method) => {
-  loadingBar.start();
-  return request[method](API_URL + url, req.data, {
+  const headers = {
     'Content-Language': language,
     ...req.headers,
     'X-Requested-With': 'XMLHttpRequest',
-  })
+  };
+
+  loadingBar.start();
+
+  return request[method](API_URL + url, req.data, headers)
     .then(doneLoading)
     .catch(e => handleError(e, { url, method }));
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uwazi",
-  "version": "1.124.1",
+  "version": "1.124.2",
   "description": "Uwazi is a free, open-source solution for organising, analysing and publishing your documents.",
   "keywords": [
     "react"


### PR DESCRIPTION
Issue with a header added rejected by Node18. 

The header is `connection`. Is being set as per our documentation in nginx for multitenants: https://uwazi.readthedocs.io/en/latest/sysadmin-docs/multi-tenant.html?highlight=tenants
