### PR TITLE
Remove wrap-range-text

### DIFF
--- a/app/react/utils/wrapper.js
+++ b/app/react/utils/wrapper.js
@@ -1,5 +1,0 @@
-import wrap from 'wrap-range-text';
-
-export default {
-  wrap: (wrapper, range) => wrap(wrapper, range),
-};

--- a/package.json
+++ b/package.json
@@ -237,7 +237,6 @@
     "url-join": "^4.0.1",
     "winston": "3.9.0",
     "world-countries": "4.0.0",
-    "wrap-range-text": "^1.0.1",
     "xml-js": "^1.6.11",
     "yargs": "^17.7.2",
     "yauzl": "^2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20319,10 +20319,6 @@ wrap-ansi@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-wrap-range-text@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/wrap-range-text/-/wrap-range-text-1.0.1.tgz"
-
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"


### PR DESCRIPTION
Removes obsolete package `wrap-range-text`

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
