### PR TITLE
UpdateContext v2 fix

### DIFF
--- a/app/api/i18n.v2/contracts/TranslationsDataSource.ts
+++ b/app/api/i18n.v2/contracts/TranslationsDataSource.ts
@@ -18,7 +18,5 @@ export interface TranslationsDataSource {
   updateContextLabel(contextId: string, contextLabel: string): Promise<UpdateResult<Translation>>;
   updateKeysByContext(contextId: string, keyChanges: { [k: string]: string }): Promise<void>;
 
-  updateValue(key: string, contextId: string, language: string, value: string): Promise<void>;
-
   calculateNonexistentKeys(contextId: string, keys: string[]): Promise<string[]>;
 }

--- a/app/api/i18n.v2/database/MongoTranslationsDataSource.ts
+++ b/app/api/i18n.v2/database/MongoTranslationsDataSource.ts
@@ -100,13 +100,6 @@ export class MongoTranslationsDataSource
     await stream.flush();
   }
 
-  async updateValue(key: string, contextId: string, language: LanguageISO6391, value: string) {
-    await this.getCollection().updateOne(
-      { key, 'context.id': contextId, language },
-      { $set: { value } }
-    );
-  }
-
   async deleteKeysByContext(contextId: string, keysToDelete: string[]) {
     return this.getCollection().deleteMany({ 'context.id': contextId, key: { $in: keysToDelete } });
   }

--- a/app/api/i18n.v2/services/UpsertTranslationsService.ts
+++ b/app/api/i18n.v2/services/UpsertTranslationsService.ts
@@ -61,18 +61,6 @@ export class UpsertTranslationsService {
         {}
       );
 
-      const defaultLanguageKey = await this.settingsDS.getDefaultLanguageKey();
-
-      await Object.entries(valueChanges).reduce(async (previous, [key, value]) => {
-        await previous;
-        await this.translationsDS.updateValue(
-          keysChangedReversed[key] || key,
-          context.id,
-          defaultLanguageKey,
-          value
-        );
-      }, Promise.resolve());
-
       await this.createNewKeys(keysChangedReversed, valueChanges, context);
 
       await this.translationsDS.updateContextLabel(context.id, context.label);

--- a/app/api/i18n.v2/services/UpsertTranslationsService.ts
+++ b/app/api/i18n.v2/services/UpsertTranslationsService.ts
@@ -67,8 +67,24 @@ export class UpsertTranslationsService {
 
       await this.translationsDS.updateKeysByContext(context.id, keyChanges);
 
+      await this.updateKeyValueOnDefaultLanguage(Object.values(keyChanges), context);
+
       await this.translationsDS.deleteKeysByContext(context.id, keysToDelete);
     });
+  }
+
+  private async updateKeyValueOnDefaultLanguage(
+    newKeys: string[],
+    context: CreateTranslationsData['context']
+  ) {
+    const defaultLanguageKey = await this.settingsDS.getDefaultLanguageKey();
+
+    await this.translationsDS.upsert(
+      newKeys.reduce<Translation[]>((memo, newKey) => {
+        memo.push(new Translation(newKey, newKey, defaultLanguageKey, context));
+        return memo;
+      }, [])
+    );
   }
 
   private async createNewKeys(

--- a/app/api/i18n/specs/fixtures.ts
+++ b/app/api/i18n/specs/fixtures.ts
@@ -27,6 +27,11 @@ const translationsV2: DBFixture['translationsV2'] = [
     label: 'System',
     type: 'Uwazi UI',
   }),
+  createTranslationDBO('property should not change', 'property', 'zh', {
+    id: dictionaryId.toString(),
+    label: 'Dictionary',
+    type: 'Thesaurus',
+  }),
   createTranslationDBO('Age', 'Edad', 'zh', {
     id: dictionaryId.toString(),
     label: 'Dictionary',
@@ -48,6 +53,11 @@ const translationsV2: DBFixture['translationsV2'] = [
     type: 'Thesaurus',
   }),
   createTranslationDBO('dictionary 2', 'dictionary 2', 'zh', {
+    id: dictionaryId.toString(),
+    label: 'Dictionary',
+    type: 'Thesaurus',
+  }),
+  createTranslationDBO('property should not change', 'property', 'es', {
     id: dictionaryId.toString(),
     label: 'Dictionary',
     type: 'Thesaurus',
@@ -97,6 +107,11 @@ const translationsV2: DBFixture['translationsV2'] = [
     id: 'System',
     label: 'System',
     type: 'Uwazi UI',
+  }),
+  createTranslationDBO('property should not change', 'property', 'en', {
+    id: dictionaryId.toString(),
+    label: 'Dictionary',
+    type: 'Thesaurus',
   }),
   createTranslationDBO('Age', 'Age', 'en', {
     id: dictionaryId.toString(),

--- a/app/api/i18n/specs/fixtures.ts
+++ b/app/api/i18n/specs/fixtures.ts
@@ -27,7 +27,7 @@ const translationsV2: DBFixture['translationsV2'] = [
     label: 'System',
     type: 'Uwazi UI',
   }),
-  createTranslationDBO('property should not change', 'property', 'zh', {
+  createTranslationDBO('property should only change value on default languge', 'property', 'zh', {
     id: dictionaryId.toString(),
     label: 'Dictionary',
     type: 'Thesaurus',
@@ -57,7 +57,7 @@ const translationsV2: DBFixture['translationsV2'] = [
     label: 'Dictionary',
     type: 'Thesaurus',
   }),
-  createTranslationDBO('property should not change', 'property', 'es', {
+  createTranslationDBO('property should only change value on default languge', 'property', 'es', {
     id: dictionaryId.toString(),
     label: 'Dictionary',
     type: 'Thesaurus',
@@ -108,7 +108,7 @@ const translationsV2: DBFixture['translationsV2'] = [
     label: 'System',
     type: 'Uwazi UI',
   }),
-  createTranslationDBO('property should not change', 'property', 'en', {
+  createTranslationDBO('property should only change value on default languge', 'property', 'en', {
     id: dictionaryId.toString(),
     label: 'Dictionary',
     type: 'Thesaurus',

--- a/app/api/i18n/specs/translations_v2_support.spec.ts
+++ b/app/api/i18n/specs/translations_v2_support.spec.ts
@@ -724,14 +724,50 @@ describe('translations v2 support', () => {
 
   describe('updateContext', () => {
     describe('when feature flag is on', () => {
+      it('should change the value of a translation when changing the key if the locale is the default one', async () => {
+        testingTenants.changeCurrentTenant({ featureFlags: { translationsV2: true } });
+        await testingDB.setupFixturesAndContext(fixtures);
+        await translations.get();
+
+        const values = {};
+
+        await translations.updateContext(
+          { id: dictionaryId.toString(), label: 'new context name', type: 'Thesaurus' },
+          { 'property should only change value on default languge': 'new property name' },
+          [],
+          values
+        );
+
+        const [propertyES] = await db
+          .collection(newTranslationsCollection)
+          .find({ key: 'new property name', language: 'es' })
+          .toArray();
+
+        const [propertyEN] = await db
+          .collection(newTranslationsCollection)
+          .find({ key: 'new property name', language: 'en' })
+          .toArray();
+
+        const [propertyZH] = await db
+          .collection(newTranslationsCollection)
+          .find({ key: 'new property name', language: 'zh' })
+          .toArray();
+
+        expect(propertyES.value).toBe('property');
+        expect(propertyZH.value).toBe('property');
+        expect(propertyEN.value).toBe('new property name');
+      });
+
       it('should properly change context name, key names, values for the keys changed and deleteProperties, and create new values as new translations if key does not exists', async () => {
+        //changed keys should change value also when the locale is the default one
+        //! use the previous commit to remove the update and then implement the key change functionality
         testingTenants.changeCurrentTenant({ featureFlags: { translationsV2: true } });
         await testingDB.setupFixturesAndContext(fixtures);
         await translations.get();
 
         const values = {
           'new key': 'new value',
-          'property should not change': 'new value',
+          'property should only change value on default languge': 'new value',
         };
 
         await translations.updateContext(
@@ -751,13 +787,13 @@ describe('translations v2 support', () => {
           {
             language: 'en',
             key: 'New Account Key',
-            value: 'Account',
+            value: 'New Account Key',
             context: { type: 'Thesaurus', label: 'new context name', id: dictionaryId.toString() },
           },
           {
             language: 'en',
             key: 'New Password key',
-            value: 'Password',
+            value: 'New Password key',
             context: { type: 'Thesaurus', label: 'new context name', id: dictionaryId.toString() },
           },
           {
@@ -774,7 +810,7 @@ describe('translations v2 support', () => {
           },
           {
             language: 'en',
-            key: 'property should not change',
+            key: 'property should only change value on default languge',
             value: 'property',
             context: { type: 'Thesaurus', label: 'new context name', id: dictionaryId.toString() },
           },
@@ -807,7 +843,7 @@ describe('translations v2 support', () => {
           },
           {
             language: 'es',
-            key: 'property should not change',
+            key: 'property should only change value on default languge',
             value: 'property',
             context: { type: 'Thesaurus', label: 'new context name', id: dictionaryId.toString() },
           },

--- a/app/api/i18n/specs/translations_v2_support.spec.ts
+++ b/app/api/i18n/specs/translations_v2_support.spec.ts
@@ -724,14 +724,14 @@ describe('translations v2 support', () => {
 
   describe('updateContext', () => {
     describe('when feature flag is on', () => {
-      it('should properly change context name, key names, values for the keys changed and deleteProperties, and create new values as new translations', async () => {
+      it('should properly change context name, key names, values for the keys changed and deleteProperties, and create new values as new translations if key does not exists', async () => {
         testingTenants.changeCurrentTenant({ featureFlags: { translationsV2: true } });
         await testingDB.setupFixturesAndContext(fixtures);
         await translations.get();
 
         const values = {
-          'New Account Key': 'Account edited',
           'new key': 'new value',
+          'property should not change': 'new value',
         };
 
         await translations.updateContext(
@@ -751,7 +751,7 @@ describe('translations v2 support', () => {
           {
             language: 'en',
             key: 'New Account Key',
-            value: 'Account edited',
+            value: 'Account',
             context: { type: 'Thesaurus', label: 'new context name', id: dictionaryId.toString() },
           },
           {
@@ -770,6 +770,12 @@ describe('translations v2 support', () => {
             language: 'en',
             key: 'new key',
             value: 'new value',
+            context: { type: 'Thesaurus', label: 'new context name', id: dictionaryId.toString() },
+          },
+          {
+            language: 'en',
+            key: 'property should not change',
+            value: 'property',
             context: { type: 'Thesaurus', label: 'new context name', id: dictionaryId.toString() },
           },
         ]);
@@ -797,6 +803,12 @@ describe('translations v2 support', () => {
             language: 'es',
             key: 'new key',
             value: 'new value',
+            context: { type: 'Thesaurus', label: 'new context name', id: dictionaryId.toString() },
+          },
+          {
+            language: 'es',
+            key: 'property should not change',
+            value: 'property',
             context: { type: 'Thesaurus', label: 'new context name', id: dictionaryId.toString() },
           },
         ]);


### PR DESCRIPTION
When changing a key, updatecontext v2 was also updating all the values, now it only updates the value for the default Language, same behavior of v1

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
