### PR TITLE
[Stabilization fix] V2 media fields failing

### DIFF
--- a/app/react/Metadata/components/Metadata.js
+++ b/app/react/Metadata/components/Metadata.js
@@ -235,12 +235,12 @@ const Metadata = ({
     const highlightClass = highlight.includes(prop.name) ? 'highlight' : '';
     const fullWidthClass = prop.fullWidth ? 'full-width' : '';
 
-    if (type === 'multimedia' && useV2Player && attachments) {
+    if (prop.type === 'media' && useV2Player && attachments) {
       const { filename, url } = getMediaUrlAndName(prop.value);
 
       if (url.startsWith('/api/files')) {
         prop.fileName =
-          attachments.find(attachment => attachment.filename === filename).originalname || '';
+          attachments.find(attachment => attachment.filename === filename)?.originalname || '';
       }
 
       prop.value = url;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uwazi",
-  "version": "1.134.0-rc2",
+  "version": "1.134.0-rc3",
   "description": "Uwazi is a free, open-source solution for organising, analysing and publishing your documents.",
   "keywords": [
     "react"


### PR DESCRIPTION
This error was caused by lines
https://github.com/huridocs/uwazi/blob/1d92ea23631cbd8509039d2d2108b59291c0f043/app/react/Metadata/components/Metadata.js#L234-L238

Where the `if` statement was using the `type` local var instead of the original `prop.type`. This caused that pdf preview fields on cards where treated as media fields, triggering a failure when trying to find the media field file's original name to display on the thumbnail, used by v2 media fields.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
