### PR TITLE
[HOTFIX] migration to remove translations v1 traces

### DIFF
--- a/app/api/migrations/migrations/146-remove_translationsv2_traces/index.js
+++ b/app/api/migrations/migrations/146-remove_translationsv2_traces/index.js
@@ -1,0 +1,15 @@
+export default {
+  delta: 146,
+
+  name: 'remove_translationsv2_traces',
+
+  description: 'remove translations collection and translations updatelogs',
+
+  reindex: false,
+
+  async up(db) {
+    process.stdout.write(`${this.name}...\r\n`);
+    await db.collection('translations').drop();
+    await db.collection('updatelogs').deleteMany({ namespace: 'translations' });
+  },
+};

--- a/app/api/migrations/migrations/146-remove_translationsv2_traces/specs/146-remove_translationsv2_traces.spec.js
+++ b/app/api/migrations/migrations/146-remove_translationsv2_traces/specs/146-remove_translationsv2_traces.spec.js
@@ -1,0 +1,34 @@
+import testingDB from 'api/utils/testing_db';
+import migration from '../index.js';
+import { fixtures } from './fixtures.js';
+
+describe('migration remove_translationsv2_traces', () => {
+  beforeEach(async () => {
+    jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
+    await testingDB.setupFixturesAndContext(fixtures);
+  });
+
+  afterAll(async () => {
+    await testingDB.tearDown();
+  });
+
+  it('should have a delta number', () => {
+    expect(migration.delta).toBe(146);
+  });
+
+  it('should check if a reindex is needed', async () => {
+    expect(migration.reindex).toBe(false);
+  });
+
+  it('should delete translations collection', async () => {
+    await migration.up(testingDB.mongodb);
+    const collectionNames = (await testingDB.mongodb.listCollections().toArray()).map(c => c.name);
+    expect(collectionNames.includes('translations')).toBe(false);
+  });
+
+  it('should delete all translations entries in updatelogs', async () => {
+    await migration.up(testingDB.mongodb);
+    const updatelogs = await testingDB.mongodb.collection('updatelogs').find().toArray();
+    expect(updatelogs).toMatchObject([{ namespace: 'migrations' }, { namespace: 'entities' }]);
+  });
+});

--- a/app/api/migrations/migrations/146-remove_translationsv2_traces/specs/fixtures.js
+++ b/app/api/migrations/migrations/146-remove_translationsv2_traces/specs/fixtures.js
@@ -1,5 +1,3 @@
-import db from 'api/utils/testing_db';
-
 export const fixtures = {
   translations: [{}],
   updatelogs: [

--- a/app/api/migrations/migrations/146-remove_translationsv2_traces/specs/fixtures.js
+++ b/app/api/migrations/migrations/146-remove_translationsv2_traces/specs/fixtures.js
@@ -1,0 +1,11 @@
+import db from 'api/utils/testing_db';
+
+export const fixtures = {
+  translations: [{}],
+  updatelogs: [
+    { namespace: 'migrations' },
+    { namespace: 'translations' },
+    { namespace: 'entities' },
+    { namespace: 'translations' },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uwazi",
-  "version": "1.138.0",
+  "version": "1.138.1",
   "description": "Uwazi is a free, open-source solution for organising, analysing and publishing your documents.",
   "keywords": [
     "react"

--- a/scripts/checkTranslations.mjs
+++ b/scripts/checkTranslations.mjs
@@ -130,11 +130,9 @@ const getClient = async () => {
 const getSystemUITranslations = async () => {
   const client = await getClient();
   const db = client.db(process.env.DATABASE_NAME || 'uwazi_development');
-  const collection = db.collection('translations');
-  const [firstTranslation] = await collection.find().toArray();
-  const systemContext = firstTranslation.contexts.find(c => c.id === 'System');
+  const collection = db.collection('translationsV2');
+  const translations = await collection.find({ 'context.id': 'System' }).toArray();
   client.close();
-  const translations = systemContext.values;
   const comparableTranslations = translations.map(t => ({
     ...t,
     plainValue: comparableString(t.value),


### PR DESCRIPTION
* Remove translations collection (not used anymore)
* Remove updatelogs for translations (clean up and prevent sync errors)
* Fix checkTranslations to work with the new translationsV2 collection

