### PR TITLE
Atomstore templates and thesauri

### DIFF
--- a/app/react/App/styles/globals.css
+++ b/app/react/App/styles/globals.css
@@ -1867,10 +1867,6 @@ input[type="range"]::-ms-fill-lower {
   height: 3.5rem;
 }
 
-.h-2 {
-  height: 0.5rem;
-}
-
 .h-3 {
   height: 0.75rem;
 }
@@ -1922,10 +1918,6 @@ input[type="range"]::-ms-fill-lower {
 
 .h-full {
   height: 100%;
-}
-
-.h-\[36px\] {
-  height: 36px;
 }
 
 .max-h-16 {
@@ -2143,14 +2135,6 @@ input[type="range"]::-ms-fill-lower {
   width: max-content;
 }
 
-.w-\[36px\] {
-  width: 36px;
-}
-
-.w-\[35px\] {
-  width: 35px;
-}
-
 .min-w-20 {
   min-width: 5rem;
 }
@@ -2211,6 +2195,10 @@ input[type="range"]::-ms-fill-lower {
   max-width: 120px;
 }
 
+.max-w-\[188px\] {
+  max-width: 188px;
+}
+
 .max-w-lg {
   max-width: 32rem;
 }
@@ -2229,38 +2217,6 @@ input[type="range"]::-ms-fill-lower {
 
 .max-w-xs {
   max-width: 20rem;
-}
-
-.max-w-\[400px\] {
-  max-width: 400px;
-}
-
-.max-w-\[200px\] {
-  max-width: 200px;
-}
-
-.max-w-\[220px\] {
-  max-width: 220px;
-}
-
-.max-w-\[180px\] {
-  max-width: 180px;
-}
-
-.max-w-\[175px\] {
-  max-width: 175px;
-}
-
-.max-w-\[172px\] {
-  max-width: 172px;
-}
-
-.max-w-\[182px\] {
-  max-width: 182px;
-}
-
-.max-w-\[188px\] {
-  max-width: 188px;
 }
 
 .flex-1 {
@@ -2736,6 +2692,11 @@ input[type="range"]::-ms-fill-lower {
   border-color: rgb(157 23 77 / var(--tw-border-opacity));
 }
 
+.border-gray-100 {
+  --tw-border-opacity: 1;
+  border-color: rgb(243 244 246 / var(--tw-border-opacity));
+}
+
 .border-gray-200 {
   --tw-border-opacity: 1;
   border-color: rgb(229 231 235 / var(--tw-border-opacity));
@@ -2798,11 +2759,6 @@ input[type="range"]::-ms-fill-lower {
 .border-warning-300 {
   --tw-border-opacity: 1;
   border-color: rgb(253 224 71 / var(--tw-border-opacity));
-}
-
-.border-gray-100 {
-  --tw-border-opacity: 1;
-  border-color: rgb(243 244 246 / var(--tw-border-opacity));
 }
 
 .border-t-gray-200 {
@@ -2981,10 +2937,6 @@ input[type="range"]::-ms-fill-lower {
 .bg-yellow-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(253 246 178 / var(--tw-bg-opacity));
-}
-
-.bg-\[color\] {
-  background-color: color;
 }
 
 .bg-opacity-50 {
@@ -3890,21 +3842,6 @@ input[type="range"]::-ms-fill-lower {
 .focus\:ring-success-200:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(187 247 208 / var(--tw-ring-opacity));
-}
-
-.focus-visible\:border-error-900:focus-visible {
-  --tw-border-opacity: 1;
-  border-color: rgb(131 24 67 / var(--tw-border-opacity));
-}
-
-.focus-visible\:border-error-300:focus-visible {
-  --tw-border-opacity: 1;
-  border-color: rgb(249 168 212 / var(--tw-border-opacity));
-}
-
-.focus-visible\:border-gray-300:focus-visible {
-  --tw-border-opacity: 1;
-  border-color: rgb(209 213 219 / var(--tw-border-opacity));
 }
 
 .focus-visible\:outline-none:focus-visible {

--- a/app/react/V2/Routes/Settings/IX/components/PDFSidepanel.tsx
+++ b/app/react/V2/Routes/Settings/IX/components/PDFSidepanel.tsx
@@ -20,10 +20,9 @@ import * as filesAPI from 'V2/api/files';
 import * as entitiesAPI from 'V2/api/entities';
 import { secondsToISODate } from 'V2/shared/dateHelpers';
 import { Button, Sidepanel } from 'V2/Components/UI';
-import { InputField } from 'V2/Components/Forms';
+import { InputField, MultiselectList } from 'V2/Components/Forms';
 import { PDF, selectionHandlers } from 'V2/Components/PDFViewer';
-import { notificationAtom, thesaurisAtom } from 'V2/atoms';
-import { MultiselectList } from 'V2/Components/Forms';
+import { notificationAtom, thesauriAtom } from 'V2/atoms';
 import { Highlights } from '../types';
 
 interface PDFSidepanelProps {
@@ -147,7 +146,7 @@ const PDFSidepanel = ({
   const [entity, setEntity] = useState<ClientEntitySchema>();
   const [thesaurus, setThesaurus] = useState<any>();
   const setNotifications = useSetAtom(notificationAtom);
-  const thesauris = useAtomValue(thesaurisAtom);
+  const thesauris = useAtomValue(thesauriAtom);
 
   const templateId = suggestion?.entityTemplateId;
   const propertyValue = getFormValue(suggestion, entity, property?.type);
@@ -404,7 +403,7 @@ const PDFSidepanel = ({
       <Sidepanel.Body>
         <form
           id="ixpdfform"
-          className="flex flex-col h-full gap-4 pb-0"
+          className="flex flex-col gap-4 pb-0 h-full"
           onSubmit={handleSubmit(onSubmit)}
         >
           <div ref={pdfContainerRef} className="md:m-auto md:w-[95%] grow">
@@ -430,7 +429,7 @@ const PDFSidepanel = ({
           </div>
         </form>{' '}
       </Sidepanel.Body>
-      <Sidepanel.Footer className="py-0 border border-b-0 border-l-0 border-r-0 border-gray-200 border-t-1">
+      <Sidepanel.Footer className="py-0 border border-r-0 border-b-0 border-l-0 border-gray-200 border-t-1">
         <div className="flex px-4 py-2">
           <p className={selectionError ? 'text-pink-600 grow' : 'grow'}>
             <Translate className="uppercase" context={templateId}>
@@ -443,7 +442,7 @@ const PDFSidepanel = ({
           </span>
         </div>
         {labelInputIsOpen && renderLabel()}
-        <div className="flex justify-end gap-2 px-4 py-2 border border-b-0 border-l-0 border-r-0 border-gray-200 border-t-1">
+        <div className="flex gap-2 justify-end px-4 py-2 border border-r-0 border-b-0 border-l-0 border-gray-200 border-t-1">
           <Button
             type="button"
             styling="outline"

--- a/app/react/V2/Routes/Settings/IX/components/SuggestedValue.tsx
+++ b/app/react/V2/Routes/Settings/IX/components/SuggestedValue.tsx
@@ -7,7 +7,7 @@ import { secondsToDate } from 'app/V2/shared/dateHelpers';
 import { EntitySuggestionType } from 'shared/types/suggestionType';
 import { ClientTemplateSchema } from 'app/istore';
 import { Translate } from 'app/I18N';
-import { thesaurisAtom } from 'app/V2/atoms';
+import { thesauriAtom } from 'V2/atoms';
 
 const SuggestedValue = ({
   value,
@@ -28,7 +28,7 @@ const SuggestedValue = ({
     modifiers: [{ name: 'arrow', options: { element: arrowElement } }],
   });
   const [popoverOpen, setPopoverOpen] = useState(false);
-  const thesauris = useAtomValue(thesaurisAtom);
+  const thesauris = useAtomValue(thesauriAtom);
 
   let colorClass = '';
   if (!suggestion || suggestion.suggestedValue === '') {

--- a/app/react/V2/atoms/index.ts
+++ b/app/react/V2/atoms/index.ts
@@ -3,7 +3,7 @@ export { notificationAtom } from './notificationAtom';
 export { settingsAtom } from './settingsAtom';
 export { templatesAtom } from './templatesAtom';
 export { translationsAtom } from './translationsAtom';
-export { thesaurisAtom } from './thesaurisAtom';
+export { thesauriAtom } from './thesauriAtom';
 export { globalMatomoAtom } from './globalMatomoAtom';
 export { userAtom } from './userAtom';
 export type { AtomStoreData } from './store';

--- a/app/react/V2/atoms/store.ts
+++ b/app/react/V2/atoms/store.ts
@@ -1,18 +1,22 @@
 import { createStore } from 'jotai';
 import { isClient } from 'app/utils';
 import { store } from 'app/store';
-import { ClientSettings, ClientUserSchema } from 'app/apiResponseTypes';
+import { ClientSettings, ClientThesaurus, ClientUserSchema } from 'app/apiResponseTypes';
+import { ClientTemplateSchema } from 'app/istore';
 import { globalMatomoAtom } from './globalMatomoAtom';
 import { relationshipTypesAtom } from './relationshipTypes';
 import { settingsAtom } from './settingsAtom';
 import { templatesAtom } from './templatesAtom';
 import { translationsAtom } from './translationsAtom';
 import { userAtom } from './userAtom';
+import { thesauriAtom } from './thesauriAtom';
 
 type AtomStoreData = {
   globalMatomo?: { url: string; id: string };
   locale?: string;
   settings?: ClientSettings;
+  thesauri?: ClientThesaurus[];
+  templates?: ClientTemplateSchema[];
   user?: ClientUserSchema;
 };
 
@@ -25,10 +29,12 @@ declare global {
 const atomStore = createStore();
 
 if (isClient && window.__atomStoreData__) {
-  const { globalMatomo, locale, settings, user } = window.__atomStoreData__;
+  const { globalMatomo, locale, settings, thesauri, templates, user } = window.__atomStoreData__;
 
   if (globalMatomo) atomStore.set(globalMatomoAtom, { ...globalMatomo });
   if (settings) atomStore.set(settingsAtom, settings);
+  if (thesauri) atomStore.set(thesauriAtom, thesauri);
+  if (templates) atomStore.set(templatesAtom, templates);
   atomStore.set(userAtom, user);
   atomStore.set(translationsAtom, { locale: locale || 'en' });
 

--- a/app/react/V2/atoms/thesauriAtom.ts
+++ b/app/react/V2/atoms/thesauriAtom.ts
@@ -1,6 +1,6 @@
 import { atom } from 'jotai';
 import { ClientThesaurus } from 'app/apiResponseTypes';
 
-const thesaurisAtom = atom([] as ClientThesaurus[]);
+const thesauriAtom = atom([] as ClientThesaurus[]);
 
-export { thesaurisAtom };
+export { thesauriAtom };

--- a/app/react/entry-server.tsx
+++ b/app/react/entry-server.tsx
@@ -160,6 +160,8 @@ const prepareStores = async (req: ExpressRequest, settings: ClientSettings, lang
     atomStoreData: {
       locale,
       settings: settingsApiResponse.json,
+      thesauri: thesaurisApiResponse.json.rows,
+      templates: templatesApiResponse.json.rows,
       user: userApiResponse.json,
     },
   };


### PR DESCRIPTION
continuation from https://github.com/huridocs/uwazi/pull/6767 to add thesauri and templates to the initial atom store, needed for IX.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
