### PR TITLE
Force files download

### DIFF
--- a/app/react/App/styles/globals.css
+++ b/app/react/App/styles/globals.css
@@ -3469,6 +3469,11 @@ input[type="range"]::-ms-fill-lower {
   color: rgb(255 138 76 / var(--tw-text-opacity));
 }
 
+.text-orange-500 {
+  --tw-text-opacity: 1;
+  color: rgb(255 90 31 / var(--tw-text-opacity));
+}
+
 .text-orange-600 {
   --tw-text-opacity: 1;
   color: rgb(208 56 1 / var(--tw-text-opacity));
@@ -3537,11 +3542,6 @@ input[type="range"]::-ms-fill-lower {
 .text-yellow-800 {
   --tw-text-opacity: 1;
   color: rgb(114 59 19 / var(--tw-text-opacity));
-}
-
-.text-orange-500 {
-  --tw-text-opacity: 1;
-  color: rgb(255 90 31 / var(--tw-text-opacity));
 }
 
 .underline {

--- a/app/react/Attachments/components/Attachment.js
+++ b/app/react/Attachments/components/Attachment.js
@@ -146,6 +146,7 @@ class Attachment extends Component {
       <a
         className="attachment-link"
         href={item.url || item.downloadHref}
+        download
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -226,7 +227,12 @@ class Attachment extends Component {
                 </button>
               </li>
               <li>
-                <a href={item.url || item.downloadHref} target="_blank" rel="noopener noreferrer">
+                <a
+                  href={item.url || item.downloadHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  download
+                >
                   <Icon icon="cloud-download-alt" /> <Translate>Download</Translate>
                 </a>
               </li>

--- a/app/react/Attachments/components/File.tsx
+++ b/app/react/Attachments/components/File.tsx
@@ -115,6 +115,7 @@ class File extends Component<FileOwnProps, FileState> {
             href={`${APIURL}files/${filename}`}
             target="_blank"
             rel="noopener noreferrer"
+            download
             className="file-download btn btn-outline-secondary"
           >
             <Icon icon="cloud-download-alt" />


### PR DESCRIPTION
The goal of this PR is that when users click on supporting files, or want to download supporting files or main files, the link triggers a download instead of opening a new tab.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
