### PR TITLE
IX, remove property from extractor when removed from template

### DIFF
--- a/app/api/services/informationextraction/ixextractors.ts
+++ b/app/api/services/informationextraction/ixextractors.ts
@@ -116,6 +116,7 @@ export const Extractors = {
     await createBlankSuggestionsForExtractor(saved);
     return saved;
   },
+
   update: async (id: string, name: string, property: string, templateIds: string[]) => {
     const [extractor] = await model.get({ _id: new ObjectId(id) });
     if (!extractor) throw Error('Missing extractor.');

--- a/app/api/suggestions/specs/eventListeners.spec.ts
+++ b/app/api/suggestions/specs/eventListeners.spec.ts
@@ -1055,7 +1055,7 @@ describe(`On ${TemplateDeletedEvent.name}`, () => {
     expect(suggestions).toEqual([]);
   });
 
-  it('should not act if the feature is not enabld', async () => {
+  it('should not act if the feature is not enabled', async () => {
     await disableFeatures();
 
     const suggestions = await testingDB.mongodb?.collection('ixsuggestions').find({}).toArray();

--- a/app/react/V2/Routes/Settings/IX/components/SuggestionsTitle.tsx
+++ b/app/react/V2/Routes/Settings/IX/components/SuggestionsTitle.tsx
@@ -23,7 +23,10 @@ const SuggestionsTitle = ({
   onFiltersButtonClicked: () => void;
   activeFilters: number;
 }) => {
-  const allProperties = [...(templates[0].commonProperties || []), ...templates[0].properties];
+  const allProperties = [
+    ...(templates[0]?.commonProperties || []),
+    ...(templates[0]?.properties || []),
+  ];
   const template = allProperties.find(prop => prop.name === property);
 
   let propGraphics: string | React.ReactNode = '_';

--- a/app/react/V2/Routes/Settings/IX/components/TableElements.tsx
+++ b/app/react/V2/Routes/Settings/IX/components/TableElements.tsx
@@ -241,7 +241,10 @@ const suggestionsTableColumnsBuilder: Function = (
   acceptSuggestions: (suggestions: TableSuggestion[]) => void,
   openPdfSidepanel: (suggestion: TableSuggestion) => void
 ) => {
-  const allProperties = [...(templates[0].commonProperties || []), ...templates[0].properties];
+  const allProperties = [
+    ...(templates[0]?.commonProperties || []),
+    ...(templates[0]?.properties || []),
+  ];
 
   return [
     suggestionColumnHelper.accessor('entityTitle', {


### PR DESCRIPTION
- [ ] Prevent frontend crash when extractor has no templates
- [ ] When a property is removed from a template it should be remove from the extractor along with the suggestions for this property