### PR TITLE
6461 - Initial height for .Map in markdown

### DIFF
--- a/app/react/App/scss/modules/_markdown.scss
+++ b/app/react/App/scss/modules/_markdown.scss
@@ -148,6 +148,10 @@
   h4 {
     margin-top: 15px;
   }
+
+  .Map {
+    height: 400px;
+  }
 }
 
 .panel-body {


### PR DESCRIPTION
fixes #6461

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
