### PR TITLE
Fix generate AT config script

### DIFF
--- a/scripts/scripts.v2/generateAutomaticTranslationConfig.ts
+++ b/scripts/scripts.v2/generateAutomaticTranslationConfig.ts
@@ -28,7 +28,7 @@ import yargs from 'yargs';
       pass: process.env.DBPASS,
     };
   }
-  const semanticConfig = await import(configPath);
+  const semanticConfig = (await import(configPath)).default;
   await DB.connect(config.DBHOST, dbAuth);
   await tenants.setupTenants();
   await tenants.run(async () => {


### PR DESCRIPTION
- dynamic import adds a default key with the whole object, this was not
  passing the validator on the generate config use case
