### PR TITLE
disable rebase-strategy on development changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    rebase-strategy: 'disabled'


### PR DESCRIPTION
disables rebase-strategy to avoid re-run the pipeline over PRs generated by dependabot every time that the branch of development changes

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
