### PR TITLE
Error messages are now extracted using util.inspect

### DIFF
--- a/app/api/csv/arrangeThesauri.ts
+++ b/app/api/csv/arrangeThesauri.ts
@@ -21,15 +21,12 @@ import { LabelInfoBase } from './typeParsers/select';
 import { headerWithLanguage } from './csvDefinitions';
 
 class ArrangeThesauriError extends Error {
-  source: Error;
-
   row: CSVRow;
 
   index: number;
 
   constructor(source: Error, row: CSVRow, index: number) {
-    super(source.message);
-    this.source = source;
+    super(source.message, { cause: source });
     this.row = row;
     this.index = index;
   }
@@ -163,9 +160,7 @@ const tryAddingLabel = (
   const map = thesauriValueData[id];
   if (isStandaloneGroup(map, labelInfo)) {
     throw new Error(
-      `The label "${
-        labelInfo.label
-      }" at property "${name}" is a group label in line:\n${JSON.stringify(row)}`
+      `The label "${labelInfo.label}" at property "${name}" is a group label in line:\n${JSON.stringify(row)}`
     );
   }
   const { childInfo, parentInfo } = pickParentChild(labelInfo);

--- a/app/api/files/S3Storage.ts
+++ b/app/api/files/S3Storage.ts
@@ -9,11 +9,8 @@ import {
 import { config } from 'api/config';
 
 class S3TimeoutError extends Error {
-  readonly s3TimeoutError: Error;
-
-  constructor(s3TimeoutError: Error) {
-    super(s3TimeoutError.message);
-    this.s3TimeoutError = s3TimeoutError;
+  constructor(cause: Error) {
+    super(cause.message, { cause });
   }
 }
 

--- a/app/api/utils/handleError.js
+++ b/app/api/utils/handleError.js
@@ -1,11 +1,12 @@
-import { legacyLogger } from 'api/log';
 import Ajv from 'ajv';
-import { createError } from 'api/utils/index';
-import { appContext } from 'api/utils/AppContext';
 import { UnauthorizedError } from 'api/authorization.v2/errors/UnauthorizedError';
 import { ValidationError } from 'api/common.v2/validation/ValidationError';
 import { FileNotFound } from 'api/files/FileNotFound';
 import { S3TimeoutError } from 'api/files/S3Storage';
+import { legacyLogger } from 'api/log';
+import { appContext } from 'api/utils/AppContext';
+import { createError } from 'api/utils/index';
+import util from 'node:util';
 
 const ajvPrettifier = error => {
   const errorMessage = [error.message];
@@ -60,11 +61,11 @@ const prettifyError = (error, { req = {}, uncaught = false } = {}) => {
   let result = error;
 
   if (error instanceof Error) {
-    result = { code: 500, message: error.stack, logLevel: 'error' };
+    result = { code: 500, message: util.inspect(error), logLevel: 'error' };
   }
 
   if (error instanceof S3TimeoutError) {
-    result = { code: 408, message: `${error.message}\n${error.stack}`, logLevel: 'debug' };
+    result = { code: 408, message: util.inspect(error), logLevel: 'debug' };
   }
 
   if (error instanceof Ajv.ValidationError) {

--- a/app/api/utils/specs/handleError.spec.js
+++ b/app/api/utils/specs/handleError.spec.js
@@ -1,10 +1,11 @@
-import { createError } from 'api/utils';
 import { legacyLogger } from 'api/log';
+import { createError } from 'api/utils';
 
 import { errors as elasticErrors } from '@elastic/elasticsearch';
-import { appContext } from 'api/utils/AppContext';
-import { handleError, prettifyError } from '../handleError';
 import { S3TimeoutError } from 'api/files/S3Storage';
+import { appContext } from 'api/utils/AppContext';
+import util from 'node:util';
+import { handleError, prettifyError } from '../handleError';
 
 const contextRequestId = '1234';
 
@@ -48,7 +49,7 @@ describe('handleError', () => {
         handleError(error);
 
         expect(legacyLogger.error).toHaveBeenCalledWith(
-          `requestId: ${contextRequestId} \n${error.stack}
+          `requestId: ${contextRequestId} \n${util.inspect(error)}
 original error: {
  "name": "ConnectionError",
  "meta": {


### PR DESCRIPTION
util.inspect used for new errors and "500" or unknown errors, util.inspect pretty prints the error nicely and we can use the new error cause parameter to wrap builtin errors, to avoid potentially hiding error information

