### PR TITLE
remove /api/entities/get_raw_page endpoint

### DIFF
--- a/app/api/entities/routes.js
+++ b/app/api/entities/routes.js
@@ -140,29 +140,6 @@ export default app => {
   );
 
   app.get(
-    '/api/entities/get_raw_page',
-    validation.validateRequest({
-      type: 'object',
-      properties: {
-        query: {
-          type: 'object',
-          properties: {
-            sharedId: { type: 'string' },
-            pageNumber: { type: 'number' },
-          },
-          required: ['sharedId', 'pageNumber'],
-        },
-      },
-      required: ['query'],
-    }),
-    (req, res, next) =>
-      entities
-        .getRawPage(req.query.sharedId, req.language, req.query.pageNumber)
-        .then(data => res.json({ data }))
-        .catch(next)
-  );
-
-  app.get(
     '/api/entities',
     parseQuery,
     validation.validateRequest({

--- a/app/api/entities/specs/deprecatedRoutes.spec.js
+++ b/app/api/entities/specs/deprecatedRoutes.spec.js
@@ -318,16 +318,14 @@ describe('entities', () => {
     });
   });
 
-  describe('/api/entities/get_raw_page', () => {
-    it('should return formattedPlainTextPages page requested', async () => {
-      jest.spyOn(entities, 'countByTemplate').mockImplementation(async () => Promise.resolve(2));
-      const req = { query: { templateId: 'templateId' } };
+  it('should return formattedPlainTextPages page requested', async () => {
+    jest.spyOn(entities, 'countByTemplate').mockImplementation(async () => Promise.resolve(2));
+    const req = { query: { templateId: 'templateId' } };
 
-      const response = await routes.get('/api/entities/count_by_template', req);
+    const response = await routes.get('/api/entities/count_by_template', req);
 
-      expect(entities.countByTemplate).toHaveBeenCalledWith('templateId');
-      expect(response).toEqual(2);
-    });
+    expect(entities.countByTemplate).toHaveBeenCalledWith('templateId');
+    expect(response).toEqual(2);
   });
 
   describe('/api/entities/count_by_template', () => {


### PR DESCRIPTION
Changes

It was deleted the `/api/entities/get_raw_page` because is not used anymore in code base and also it was calling `entites.getRawPage` as data source, the problem is that `getRawPage` is not even declared on `entities` object.

I believe this feature was moved  from `/api/entities/get_raw_page` to `api/documents/page` because the front-end code is still using `getRawPage` but pointing to  `api/documents/page`



````
  async getRawPage(requestParams) {
    const response = await api.get(
      'documents/page',
      requestParams.add({ page: requestParams.data.page || 1 })
    );
    return response.json.data;
  },