### PR TITLE
Added some more tech debt to improve AT performance

### DIFF
--- a/app/api/entities.v2/contracts/EntitiesDataSource.ts
+++ b/app/api/entities.v2/contracts/EntitiesDataSource.ts
@@ -6,6 +6,7 @@ type MarkAsChangedData = { property: string } | { properties: string[] };
 export type MarkAsChangedItems = MarkAsChangedCriteria & MarkAsChangedData;
 
 export interface EntitiesDataSource {
+  updateEntities_OnlyUpdateAndReindex(entity: Entity): Promise<void>;
   updateEntity(entity: Entity): Promise<void>;
   updateObsoleteMetadataValues(
     id: Entity['_id'],

--- a/app/api/externalIntegrations.v2/automaticTranslation/RequestEntityTranslation.ts
+++ b/app/api/externalIntegrations.v2/automaticTranslation/RequestEntityTranslation.ts
@@ -101,7 +101,7 @@ export class RequestEntityTranslation {
     await Promise.all(
       updatedEntities.map(async updatedEntity => {
         this.logger.info(`[AT] - Pending translation saved on DB for entity - ${entity._id}`);
-        await this.entitiesDS.updateEntity(updatedEntity);
+        await this.entitiesDS.updateEntities_OnlyUpdateAndReindex(updatedEntity);
       })
     );
   }


### PR DESCRIPTION
RequestEntityTranslations saves entities using v1 model and reindex them bypassing many unneeded expensive processes by entitiesv1 save method.

