### PR TITLE
AT entity creation event listener fix

### DIFF
--- a/app/api/externalIntegrations.v2/automaticTranslation/adapters/driving/ATEntityCreationListener.ts
+++ b/app/api/externalIntegrations.v2/automaticTranslation/adapters/driving/ATEntityCreationListener.ts
@@ -1,8 +1,7 @@
+import { DefaultTransactionManager } from 'api/common.v2/database/data_source_defaults';
 import { EntityCreatedEvent } from 'api/entities/events/EntityCreatedEvent';
 import { EventsBus } from 'api/eventsbus';
-import { permissionsContext } from 'api/permissions/permissionsContext';
 import { AutomaticTranslationFactory } from '../../AutomaticTranslationFactory';
-import { DefaultTransactionManager } from 'api/common.v2/database/data_source_defaults';
 
 export class ATEntityCreationListener {
   private eventBus: EventsBus;
@@ -24,7 +23,6 @@ export class ATEntityCreationListener {
       ).get();
 
       if (active) {
-        permissionsContext.setCommandContext();
         const entityFrom = event.entities.find(e => e.language === event.targetLanguageKey) || {};
 
         entityFrom._id = entityFrom._id?.toString();

--- a/app/api/externalIntegrations.v2/automaticTranslation/adapters/driving/specs/ATEntityCreationListener.spec.ts
+++ b/app/api/externalIntegrations.v2/automaticTranslation/adapters/driving/specs/ATEntityCreationListener.spec.ts
@@ -3,12 +3,10 @@ import { EntityCreatedEvent } from 'api/entities/events/EntityCreatedEvent';
 import { EventsBus } from 'api/eventsbus';
 import { AutomaticTranslationFactory } from 'api/externalIntegrations.v2/automaticTranslation/AutomaticTranslationFactory';
 import { RequestEntityTranslation } from 'api/externalIntegrations.v2/automaticTranslation/RequestEntityTranslation';
-import { permissionsContext } from 'api/permissions/permissionsContext';
 import { tenants } from 'api/tenants';
 import { appContext } from 'api/utils/AppContext';
 import { getFixturesFactory } from 'api/utils/fixturesFactory';
 import { testingEnvironment } from 'api/utils/testingEnvironment';
-import { UserSchema } from 'shared/types/userType';
 import { ATEntityCreationListener } from '../ATEntityCreationListener';
 
 const factory = getFixturesFactory();
@@ -32,7 +30,6 @@ describe('ATEntityCreationListener', () => {
   let listener: ATEntityCreationListener;
   const eventBus: EventsBus = new EventsBus();
   let executeSpy: jest.Mock<any, any, any>;
-  let userInContext: UserSchema | undefined = {} as UserSchema;
 
   beforeEach(async () => {
     await testingEnvironment.setUp({
@@ -40,9 +37,7 @@ describe('ATEntityCreationListener', () => {
     });
     await testingEnvironment.setTenant('tenant');
 
-    executeSpy = jest.fn().mockImplementation(() => {
-      userInContext = permissionsContext.getUserInContext();
-    });
+    executeSpy = jest.fn().mockImplementation(() => {});
 
     listener = new ATEntityCreationListener(eventBus, prepareATFactory(executeSpy));
     listener.start();
@@ -87,10 +82,6 @@ describe('ATEntityCreationListener', () => {
 
       it('should execute RequestEntityTranslation on receiving entity creation event', async () => {
         expect(executeSpy).toHaveBeenCalledWith(entityEn);
-      });
-
-      it('should execute RequestEntityTranslation with commandUser as its context user', async () => {
-        expect(userInContext).toBe(permissionsContext.commandUser);
       });
     });
   });


### PR DESCRIPTION
not using permissions commandContext anymore, the listener gets executed in the same context as the entity creation, we are only separating this into a event listener / use case to decouple v1 and v2 codes.

for some reason some of the entity saves at this point ocury without the entities having _id even though they where already created and in this case the special permission commandId gets replaced on the entities leaving them "corrupted" with a wrong id.

this pr fixes the issue because we do not need to use the commandContext, but the original issue causing this potentially remains and should be understood.
