### PR TITLE
6763/index-all-documents

### DIFF
--- a/app/api/search.v2/specs/fixturesSnippetsSearch.ts
+++ b/app/api/search.v2/specs/fixturesSnippetsSearch.ts
@@ -105,6 +105,13 @@ const fixturesSnippetsSearch: DBFixture = {
       }),
     },
     {
+      ...fileWithFullText('entity1SharedId', {
+        1: 'Other[[1]] phrase[[1]] which[[1]] contains[[1]] different[[1]] data[[1]].'.repeat(5),
+        2: 'Phrase[[2]] which[[2]] contains[[2]] searched[[2]] term[[2]]. '.repeat(5),
+        3: 'Other[[3]] phrase[[3]] which[[3]] contains[[3]] different[[3]] data[[3]].'.repeat(5),
+      }),
+    },
+    {
       ...fileWithFullText('entity3SharedId', {
         1: 'Other[[1]] phrase[[1]] which[[1]] contains[[1]] different[[1]] data[[1]].'.repeat(5),
         2: 'Other[[2]] phrase[[2]] which[[2]] contains[[2]] different[[2]] data[[2]].'.repeat(5),

--- a/app/api/search.v2/specs/snippetsSearch.spec.ts
+++ b/app/api/search.v2/specs/snippetsSearch.spec.ts
@@ -39,11 +39,12 @@ describe('searchSnippets', () => {
     const expected = [
       expect.objectContaining({
         snippets: {
-          count: 2,
+          count: 3,
           metadata: [],
           fullText: [
             { page: 2, text: matches, filename: 'entity1SharedId.pdf' },
             { page: 4, text: matches, filename: 'entity1SharedId.pdf' },
+            { page: 2, text: matches, filename: 'entity1SharedId.pdf' },
           ],
         },
       }),
@@ -120,11 +121,12 @@ describe('searchSnippets', () => {
         _id: entity1enId.toString(),
         title: 'entity with a document',
         snippets: {
-          count: 2,
+          count: 3,
           metadata: [],
           fullText: [
             { page: 2, text: expect.stringContaining('<b>searched</b>') },
             { page: 4, text: expect.stringContaining('<b>searched</b>') },
+            { page: 2, text: expect.stringContaining('<b>searched</b>') },
           ],
         },
       },

--- a/app/api/search/specs/index.spec.ts
+++ b/app/api/search/specs/index.spec.ts
@@ -75,27 +75,62 @@ describe('index (search)', () => {
             title: 'test1',
             documents: [
               {
+                _id: 'fileId_1',
                 filename: 'file1',
                 fullText: { 1: 'this is an english test', 2: 'this is page2' },
               },
+              {
+                _id: 'fileId_3',
+                filename: 'file3',
+                fullText: { 1: 'test two', 2: 'this is page2' },
+              },
             ],
           },
+        ];
+
+        const expectedOutput = [
           {
-            _id: 'id2',
-            title: 'test2',
-            documents: [{ filename: 'file2', fullText: { 1: 'text3[[1]]', 2: 'text4[[2]]' } }],
+            id: 'fileId_3_id1',
+            fullText_other: 'test two\fthis is page2',
+            filename: 'file3',
+            language: 'other',
+            fullText: {
+              name: 'fullText',
+              parent: 'id1',
+            },
+          },
+          {
+            id: 'fileId_1_id1',
+            fullText_other: 'this is an english test\fthis is page2',
+            filename: 'file1',
+            language: 'other',
+            fullText: {
+              name: 'fullText',
+              parent: 'id1',
+            },
+          },
+          {
+            documents: [
+              {
+                _id: 'fileId_1',
+                filename: 'file1',
+              },
+              {
+                _id: 'fileId_3',
+                filename: 'file3',
+              },
+            ],
+            title: 'test1',
+            fullText: 'entity',
           },
         ];
 
         await search.bulkIndex(toIndexDocs);
         await elastic.indices.refresh();
 
-        expect(await elasticTesting.getIndexedEntities('')).toEqual([
-          expect.objectContaining({ title: 'test1' }),
-          expect.objectContaining({ fullText: { name: 'fullText', parent: 'id1' } }),
-          expect.objectContaining({ title: 'test2' }),
-          expect.objectContaining({ fullText: { name: 'fullText', parent: 'id2' } }),
-        ]);
+        const output = await elasticTesting.getIndexedEntities('');
+
+        expectedOutput.forEach(item => expect(output).toContainEqual(item));
       });
     });
 


### PR DESCRIPTION
This PR was created based on this issue https://github.com/huridocs/uwazi/issues/6763

## Current progress

There're two tests that I couldn't understand why it broke, so I don't have quite sure if I should update the test to cover the new behavior or it's the new implementation that really broke the code. I really need some help about this

Test failing
1. search › relationship aggregations › should return aggregations based on title of related entity
2. search › should perform a fullTextSearch on fullText and title

We are now indexing all documents for each entity, but the problem is that for every entity language we are replicating the file on elasticsearch, this might be a serious **memory** issue, for example:

If a tenant have 5 languages, one entity with 2 primary files, in practice this will generate 10 primary files. 
On mongodb, this same scenario will have only 2 primary files (files are not replicated, but reused, using relationship file<->entity, by each entity in different language)