### PR TITLE
Fix crash when importing big csv

### DIFF
--- a/app/api/csv/csv.ts
+++ b/app/api/csv/csv.ts
@@ -11,11 +11,11 @@ const peekHeaders = async (readSource: Readable | string): Promise<string[]> => 
   const readStream =
     typeof readSource === 'string' ? await importFile(readSource).readStream() : readSource;
   let headers: string[] = [];
-  const stream = csvtojson().fromStream(readStream);
-  await stream.on('header', async h => {
-    headers = h;
-    await stream.end();
-  });
+  await csvtojson()
+    .fromStream(readStream)
+    .on('header', async h => {
+      headers = h;
+    });
 
   return headers;
 };


### PR DESCRIPTION
In some cases importing big CSVs caused the application to crash.
fixes: https://github.com/huridocs/Internal-Issues/issues/224