### PR TITLE
Feat/graceful shutdown

### DIFF
--- a/app/api/log.v2/infrastructure/StandardLogger.ts
+++ b/app/api/log.v2/infrastructure/StandardLogger.ts
@@ -45,5 +45,15 @@ class StandardLogger implements Logger {
 }
 
 const DefaultLogger = (writer = UwaziJSONWriter) => new StandardLogger(writer, getTenant());
+const SystemLogger = (writer = UwaziJSONWriter) =>
+  new StandardLogger(writer, {
+    name: 'System Logger',
+    dbName: 'N/a',
+    activityLogs: 'N/a',
+    attachments: 'N/a',
+    customUploads: 'N/a',
+    indexName: 'N/a',
+    uploadedDocuments: 'N/a',
+  });
 
-export { StandardLogger, DefaultLogger };
+export { StandardLogger, DefaultLogger, SystemLogger };

--- a/app/api/services/informationextraction/InformationExtraction.ts
+++ b/app/api/services/informationextraction/InformationExtraction.ts
@@ -143,6 +143,10 @@ class InformationExtraction {
     this.taskManager.subscribeToResults();
   }
 
+  async stop() {
+    await this.taskManager.stop();
+  }
+
   requestResults = async (message: InternalIXResultsMessage) => {
     const response = await request.get(message.data_url);
 

--- a/app/api/services/pdfsegmentation/PDFSegmentation.ts
+++ b/app/api/services/pdfsegmentation/PDFSegmentation.ts
@@ -35,6 +35,10 @@ class PDFSegmentation {
     this.segmentationTaskManager.subscribeToResults();
   }
 
+  async stop() {
+    await this.segmentationTaskManager.stop();
+  }
+
   segmentOnePdf = async (
     file: { filename: string; _id: ObjectIdSchema },
     serviceUrl: string,

--- a/app/api/services/tasksmanager/DistributedLoop.ts
+++ b/app/api/services/tasksmanager/DistributedLoop.ts
@@ -80,7 +80,9 @@ export class DistributedLoop {
       handleError(error, { useContext: false });
     }
 
-    await this.waitBetweenTasks();
+    if (!this.stopTask) {
+      await this.waitBetweenTasks();
+    }
   }
 
   async stop() {

--- a/app/api/services/tasksmanager/DistributedLoop.ts
+++ b/app/api/services/tasksmanager/DistributedLoop.ts
@@ -23,6 +23,8 @@ export class DistributedLoop {
 
   private host: string;
 
+  private stopDelayTimeBetweenTasks?: Function;
+
   constructor(
     lockName: string,
     task: () => Promise<void>,
@@ -63,7 +65,11 @@ export class DistributedLoop {
 
   async waitBetweenTasks(delay = this.delayTimeBetweenTasks) {
     await new Promise(resolve => {
-      setTimeout(resolve, delay);
+      const timeout = setTimeout(resolve, delay);
+      this.stopDelayTimeBetweenTasks = () => {
+        resolve(undefined);
+        clearTimeout(timeout);
+      };
     });
   }
 
@@ -78,6 +84,7 @@ export class DistributedLoop {
   }
 
   async stop() {
+    if (this.stopDelayTimeBetweenTasks) this.stopDelayTimeBetweenTasks();
     await new Promise(resolve => {
       this.stopTask = resolve;
     });

--- a/app/api/services/tasksmanager/DistributedLoop.ts
+++ b/app/api/services/tasksmanager/DistributedLoop.ts
@@ -103,6 +103,7 @@ export class DistributedLoop {
       );
 
       if (this.stopTask) {
+        await lock.unlock();
         this.stopTask();
         return;
       }
@@ -110,9 +111,7 @@ export class DistributedLoop {
       await this.runTask();
       await lock.unlock();
     } catch (error) {
-      if (error instanceof Error && error.name !== 'LockError') {
-        throw error;
-      }
+      if (error instanceof Error && error.name !== 'LockError') throw error;
     }
 
     // eslint-disable-next-line no-void

--- a/app/api/services/tasksmanager/specs/distributedLoop.spec.js
+++ b/app/api/services/tasksmanager/specs/distributedLoop.spec.js
@@ -208,7 +208,7 @@ describe('DistributedLoopLock', () => {
     );
     const get = key =>
       new Promise((resolve, reject) => {
-        connection.keys(key, (error, data) => {
+        connection.get(key, (error, data) => {
           if (error) reject(error);
           resolve(data);
         });
@@ -228,7 +228,7 @@ describe('DistributedLoopLock', () => {
     await sleepTime(25);
     await expect(stopPromise).resolves.toBeUndefined();
 
-    const [result] = await get('*');
+    const result = await get(`locks:${lockName}`);
     expect(result).toBeFalsy();
     connection.quit();
   });

--- a/app/api/services/twitterintegration/TwitterIntegration.ts
+++ b/app/api/services/twitterintegration/TwitterIntegration.ts
@@ -49,6 +49,10 @@ class TwitterIntegration {
     this.twitterTaskManager.subscribeToResults();
   }
 
+  async stop() {
+    await this.twitterTaskManager.stop();
+  }
+
   getTwitterIntegrationSettings = async (): Promise<TwitterIntegrationSettingsType> => {
     const settingsValues = await settings.get({}, 'features');
     if (!settingsValues.features || !settingsValues.features.twitterIntegration) {

--- a/app/api/utils/Repeater.js
+++ b/app/api/utils/Repeater.js
@@ -1,13 +1,21 @@
-const timeout = async interval =>
-  new Promise(resolve => {
-    setTimeout(resolve, interval);
-  });
-
 export class Repeater {
+  stopSleep = undefined;
+
   constructor(cb, interval) {
     this.cb = cb;
     this.interval = interval;
     this.stopped = null;
+  }
+
+  async sleep() {
+    await new Promise(resolve => {
+      const timeout = setTimeout(resolve, this.interval);
+
+      this.stopSleep = () => {
+        resolve(undefined);
+        clearTimeout(timeout);
+      };
+    });
   }
 
   async start() {
@@ -15,13 +23,17 @@ export class Repeater {
       // eslint-disable-next-line no-await-in-loop
       await this.cb();
       // eslint-disable-next-line no-await-in-loop
-      await timeout(this.interval);
+      await this.sleep();
     }
 
     this.stopped();
   }
 
   async stop() {
+    if (this.stopSleep) {
+      this.stopSleep();
+    }
+
     return new Promise(resolve => {
       this.stopped = resolve;
     });

--- a/app/api/utils/specs/Repeater.spec.js
+++ b/app/api/utils/specs/Repeater.spec.js
@@ -50,4 +50,21 @@ describe('Repeater', () => {
 
     await expect(repeaterOne.stop()).resolves.toBeUndefined();
   });
+
+  it('should skip interval between executions if stop method is executed', async () => {
+    let promise;
+    let resolvePromise;
+    const sut = new Repeater(() => {
+      promise = new Promise(resolve => {
+        resolvePromise = resolve;
+      });
+
+      return promise;
+    }, 10_000);
+
+    sut.start();
+    resolvePromise();
+    await expect(promise).resolves.toBeUndefined();
+    await expect(sut.stop()).resolves.toBeUndefined();
+  }, 5_000);
 });

--- a/app/worker.ts
+++ b/app/worker.ts
@@ -65,18 +65,6 @@ DB.connect(config.DBHOST, dbAuth)
           host: config.redis.host,
           delayTimeBetweenTasks: 1000,
         }),
-        new DistributedLoop(
-          'mocktest',
-          async () => {
-            console.log('called');
-            return sleep(20000);
-          },
-          {
-            port: config.redis.port,
-            host: config.redis.host,
-            delayTimeBetweenTasks: 0,
-          }
-        ),
       ];
 
       const segmentationConnector = new PDFSegmentation();

--- a/app/worker.ts
+++ b/app/worker.ts
@@ -46,7 +46,7 @@ DB.connect(config.DBHOST, dbAuth)
     await tenants.run(async () => {
       permissionsContext.setCommandContext();
 
-      systemLogger.info('==> 📡 starting external services...');
+      systemLogger.info('[Worker] - ==> 📡 starting external services...');
 
       const services: any[] = [
         ocrManager,
@@ -90,15 +90,19 @@ DB.connect(config.DBHOST, dbAuth)
       services.forEach(service => service.start());
 
       process.on('SIGINT', async () => {
-        systemLogger.info('Received SIGINT, waiting for graceful stop...');
+        systemLogger.info(
+          '[Worker Graceful shutdown] - Received SIGINT, waiting for graceful stop...'
+        );
 
         const stopPromises = Promise.all(services.map(async service => service.stop()));
         const firstToFinish = await Promise.race([stopPromises, sleep(10_000)]);
 
         if (Array.isArray(firstToFinish)) {
-          systemLogger.info('Services stopped successfully!');
+          systemLogger.info('[Worker Graceful shutdown] - Services stopped successfully!');
         } else {
-          systemLogger.info('Some services did not stop in time, initiating forceful shutdown...');
+          systemLogger.info(
+            '[Worker Graceful shutdown] - Some services did not stop in time, initiating forceful shutdown...'
+          );
         }
 
         process.exit(0);

--- a/app/worker.ts
+++ b/app/worker.ts
@@ -93,7 +93,8 @@ DB.connect(config.DBHOST, dbAuth)
         systemLogger.info('Received SIGINT, waiting for graceful stop...');
 
         const stopPromises = Promise.all(services.map(async service => service.stop()));
-        const firstToFinish = await Promise.race([stopPromises, sleep(2000)]);
+        const firstToFinish = await Promise.race([stopPromises, sleep(10_000)]);
+
         if (Array.isArray(firstToFinish)) {
           systemLogger.info('Services stopped successfully!');
         } else {


### PR DESCRIPTION
This pull request addresses Issue https://github.com/huridocs/uwazi/issues/4850

To ensure a graceful shutdown of the Node.js process, this implementation waits for all background tasks to complete before terminating. If the background tasks exceed a 10-second timeout, the Node.Js process will be forcefully closed to avoid indefinite delays.