### PR TITLE
Redis queue creation now with "unlimited" size

### DIFF
--- a/app/api/services/tasksmanager/TaskManager.ts
+++ b/app/api/services/tasksmanager/TaskManager.ts
@@ -65,16 +65,22 @@ export class TaskManager<T = TaskMessage, R = ResultsMessage> {
     });
 
     this.redisClient.on('connect', () => {
-      this.redisSMQ.createQueue({ qname: this.taskQueue }, (err: Error | undefined) => {
-        if (err && err.name !== 'queueExists') {
-          throw err;
+      this.redisSMQ.createQueue(
+        { qname: this.taskQueue, maxsize: -1 },
+        (err: Error | undefined) => {
+          if (err && err.name !== 'queueExists') {
+            throw err;
+          }
         }
-      });
-      this.redisSMQ.createQueue({ qname: this.resultsQueue }, (err: Error | undefined) => {
-        if (err && err.name !== 'queueExists') {
-          throw err;
+      );
+      this.redisSMQ.createQueue(
+        { qname: this.resultsQueue, maxsize: -1 },
+        (err: Error | undefined) => {
+          if (err && err.name !== 'queueExists') {
+            throw err;
+          }
         }
-      });
+      );
     });
   }
 


### PR DESCRIPTION
The redis limit is 512MB but the default was 64k for the rsmq library

fixes #7398 
fixes #7383 

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
