### PR TITLE
Properly support non labeled properties to report missing segmentation

### DIFF
--- a/app/api/services/informationextraction/getFiles.ts
+++ b/app/api/services/informationextraction/getFiles.ts
@@ -126,13 +126,18 @@ async function anyFilesLabeled(
   return !!count;
 }
 
-async function anyFilesSegmented(property: string, propertyType: string) {
+async function anyFilesSegmented(
+  property: string,
+  propertyType: string,
+  entitiesFromTrainingTemplatesIds: string[]
+) {
   const needsExtractedMetadata = !propertyTypeIsWithoutExtractedMetadata(propertyType);
   const segmentedFilesCount = await filesModel.count({
     type: 'document',
     filename: { $exists: true },
     language: { $exists: true },
     _id: { $in: await getSegmentedFilesIds() },
+    entity: { $in: entitiesFromTrainingTemplatesIds },
     ...(needsExtractedMetadata ? { 'extractedMetadata.name': property } : {}),
   });
   return !!segmentedFilesCount;
@@ -183,7 +188,7 @@ async function getFilesForTraining(templates: ObjectIdSchema[], property: string
     throw new NoLabeledFiles();
   }
 
-  if (!(await anyFilesSegmented(property, propertyType))) {
+  if (!(await anyFilesSegmented(property, propertyType, entitiesFromTrainingTemplatesIds))) {
     throw new NoSegmentedFiles();
   }
 

--- a/app/api/services/informationextraction/specs/InformationExtraction.spec.ts
+++ b/app/api/services/informationextraction/specs/InformationExtraction.spec.ts
@@ -498,6 +498,18 @@ describe('InformationExtraction', () => {
       );
       expect(result).toMatchObject(expectedError);
     });
+
+    it('should return error status (No segmented files) and stop finding suggestions, when there are no segmented files (select/multiselect/relationship)', async () => {
+      const expectedError = {
+        status: 'error',
+        message: 'There are no documents segmented yet, please try again later',
+      };
+
+      const result = await informationExtraction.trainModel(
+        factory.id('selectExtractorWithoutSegmentations')
+      );
+      expect(result).toMatchObject(expectedError);
+    });
   });
 
   describe('when model is trained', () => {

--- a/app/api/services/informationextraction/specs/fixtures.ts
+++ b/app/api/services/informationextraction/specs/fixtures.ts
@@ -56,6 +56,9 @@ const fixtures: DBFixture = {
       'templateToSegmentF',
     ]),
     factory.ixExtractor('extractorWithoutSegmentations', 'title', ['templateWithoutSegmentations']),
+    factory.ixExtractor('selectExtractorWithoutSegmentations', 'property_select', [
+      'templateWithoutSegmentations',
+    ]),
   ],
   entities: [
     factory.entity('P1', 'relationshipPartnerTemplate', {}, { sharedId: 'P1sharedId' }),
@@ -139,7 +142,9 @@ const fixtures: DBFixture = {
       property_empty_relationship: [],
       property_relationship_to_any: [],
     }),
-    factory.entity('entityWithoutSegmentation', 'templateWithoutSegmentations', {}),
+    factory.entity('entityWithoutSegmentation', 'templateWithoutSegmentations', {
+      property_select: [{ value: 'B', label: 'B' }],
+    }),
   ],
   files: [
     factory.fileDeprecated('F1', 'A1', 'document', fixturesPdfNameA, 'other', '', [
@@ -781,7 +786,11 @@ const fixtures: DBFixture = {
         relationType: factory.idString('relatedToAny'),
       }),
     ]),
-    factory.template('templateWithoutSegmentations'),
+    factory.template('templateWithoutSegmentations', [
+      factory.property('property_select', 'select', {
+        content: factory.id('thesauri1').toString(),
+      }),
+    ]),
   ],
   dictionaries: [factory.nestedThesauri('thesauri1', ['A', 'B', 'C', { 1: ['1A', '1B'] }])],
 };


### PR DESCRIPTION
select/multiselect/relationship need a different approach when calculating segmented / labeled status

fixes #

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
