### PR TITLE
fix docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     container_name: mongoreplicaset_start_script
     depends_on:
       - mongo
-    entrypoint: [ "bash", "-c", "sleep 1 && mongo --host mongo:27017 --eval 'rs.initiate();cfg = rs.config(); cfg.members[0].host = \"localhost:27017\";rs.reconfig(cfg, {force:true})'"]
+    entrypoint: [ "bash", "-c", "sleep 1 && mongosh --host mongo:27017 --eval 'rs.initiate();cfg = rs.config(); cfg.members[0].host = \"localhost:27017\";rs.reconfig(cfg, {force:true})'"]
 
   redis:
     image: 'redis:5.0.14'


### PR DESCRIPTION
Now docker compose sets up replica set using mongosh, mongo is no longer available on mongodb 6.0
