### PR TITLE
Update upload-artifact for cypress

### DIFF
--- a/.github/workflows/ci_e2e_cypress_base.yml
+++ b/.github/workflows/ci_e2e_cypress_base.yml
@@ -127,12 +127,12 @@ jobs:
           DBHOST: localhost:27017
           ELASTICSEARCH_URL: http://localhost:${{ job.services.elasticsearch.ports[9200] }}
           TRANSPILED: true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: snapshots
           path: cypress/e2e/**/__image_snapshots__/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: video

--- a/.github/workflows/ci_e2e_cypress_pages.yml
+++ b/.github/workflows/ci_e2e_cypress_pages.yml
@@ -127,12 +127,12 @@ jobs:
           DBHOST: localhost:27017
           ELASTICSEARCH_URL: http://localhost:${{ job.services.elasticsearch.ports[9200] }}
           TRANSPILED: true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: snapshots
           path: cypress/e2e/**/__image_snapshots__/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: video

--- a/.github/workflows/ci_e2e_cypress_ssettings.yml
+++ b/.github/workflows/ci_e2e_cypress_ssettings.yml
@@ -127,12 +127,12 @@ jobs:
           DBHOST: localhost:27017
           ELASTICSEARCH_URL: http://localhost:${{ job.services.elasticsearch.ports[9200] }}
           TRANSPILED: true
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: snapshots
           path: cypress/e2e/**/__image_snapshots__/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: video


### PR DESCRIPTION
fixes errors in cypress workflows due to deprecation of `upload-artifact@v3` https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
