### PR TITLE
Update of translations from socket events

### DIFF
--- a/app/react/App/sockets.js
+++ b/app/react/App/sockets.js
@@ -69,7 +69,7 @@ socket.on('translationsChange', languageTranslations => {
   } else {
     translations.push(languageTranslations);
   }
-  atomStore.set(translationsAtom, translations);
+  atomStore.set(translationsAtom, [...translations]);
 });
 
 socket.on('translationKeysChange', translationsEntries => {
@@ -80,7 +80,7 @@ socket.on('translationKeysChange', translationsEntries => {
       .contexts.find(c => c.id && c.id === item.context.id);
     modifiedContext.values[item.key] = item.value;
   });
-  atomStore.set(translationsAtom, translations);
+  atomStore.set(translationsAtom, [...translations]);
 });
 
 socket.on('translationsInstallDone', () => {
@@ -109,7 +109,7 @@ socket.on('translationsInstallError', errorMessage => {
 socket.on('translationsDelete', locale => {
   const translations = atomStore.get(translationsAtom);
   const updatedTranslations = translations.filter(language => language.locale !== locale);
-  atomStore.set(translationsAtom, updatedTranslations);
+  atomStore.set(translationsAtom, [...updatedTranslations]);
 });
 
 socket.on('translationsDeleteDone', () => {

--- a/app/react/I18N/specs/fixtures.ts
+++ b/app/react/I18N/specs/fixtures.ts
@@ -45,20 +45,4 @@ const translations: ClientTranslationSchema[] = [
   },
 ];
 
-const updatedTranslations: ClientTranslationSchema[] = [
-  translations[0],
-  {
-    ...translations[1],
-    contexts: [
-      {
-        ...translations[1].contexts,
-        values: {
-          Search: 'Buscar',
-          confirmDeleteDocument: 'Actualizado!',
-        },
-      },
-    ],
-  },
-];
-
-export { translations, updatedTranslations, languages };
+export { translations, languages };

--- a/app/react/I18N/specs/translateFunction.spec.tsx
+++ b/app/react/I18N/specs/translateFunction.spec.tsx
@@ -79,7 +79,7 @@ describe('t function', () => {
       };
 
       await act(async () => {
-        //@ts-ignore accessing internal _callbacks for testing purposes 
+        //@ts-ignore accessing internal _callbacks for testing purposes
         socket._callbacks.$translationsChange[0](translation);
       });
 

--- a/app/react/I18N/specs/translateFunction.spec.tsx
+++ b/app/react/I18N/specs/translateFunction.spec.tsx
@@ -49,10 +49,6 @@ describe('t function', () => {
     });
 
     it('should update translation when the atom is updated partially from the socket', async () => {
-      await act(async () => {
-        atomStore.set(translationsAtom, [...translations]);
-      });
-
       const result = render(
         <Provider store={atomStore}>
           {t(
@@ -83,7 +79,7 @@ describe('t function', () => {
       };
 
       await act(async () => {
-        //@ts-ignore
+        //@ts-ignore accessing internal _callbacks for testing purposes 
         socket._callbacks.$translationsChange[0](translation);
       });
 
@@ -93,10 +89,6 @@ describe('t function', () => {
     });
 
     it('should update translation when the atom is updated fully from the socket', async () => {
-      await act(async () => {
-        atomStore.set(translationsAtom, [...translations]);
-      });
-
       const result = render(
         <Provider store={atomStore}> {t('System', 'Search', 'Search', true)}</Provider>
       );
@@ -116,7 +108,7 @@ describe('t function', () => {
       ];
 
       await act(async () => {
-        //@ts-ignore
+        //@ts-ignore accessing internal _callbacks for testing purposes
         socket._callbacks.$translationKeysChange[0](translationKeysChangeArguments);
       });
 

--- a/app/react/I18N/specs/translateFunction.spec.tsx
+++ b/app/react/I18N/specs/translateFunction.spec.tsx
@@ -53,11 +53,16 @@ describe('t function', () => {
         atomStore.set(translationsAtom, [...translations]);
       });
 
-      const result = render(<Provider store={atomStore}> {
-        t('System',
-          'confirmDeleteDocument',
-          'Are you sure you want to delete this document?', true)
-      }</Provider >);
+      const result = render(
+        <Provider store={atomStore}>
+          {t(
+            'System',
+            'confirmDeleteDocument',
+            'Are you sure you want to delete this document?',
+            true
+          )}
+        </Provider>
+      );
 
       expect(
         result.getByText('¿Esta seguro que quiere borrar este documento?')
@@ -71,7 +76,7 @@ describe('t function', () => {
             label: 'System',
             values: {
               Search: 'Buscar',
-              confirmDeleteDocument: '¿CONFIRMA ELIMINACION?'
+              confirmDeleteDocument: '¿CONFIRMA ELIMINACION?',
             },
           },
         ],
@@ -83,9 +88,7 @@ describe('t function', () => {
       });
 
       await act(async () => {
-        expect(
-          result.getByText('¿CONFIRMA ELIMINACION?')
-        ).toBeInTheDocument();
+        expect(result.getByText('¿CONFIRMA ELIMINACION?')).toBeInTheDocument();
       });
     });
 
@@ -94,25 +97,23 @@ describe('t function', () => {
         atomStore.set(translationsAtom, [...translations]);
       });
 
-      const result = render(<Provider store={atomStore}> {
-        t('System',
-          'Search',
-          'Search', true)
-      }</Provider >);
+      const result = render(
+        <Provider store={atomStore}> {t('System', 'Search', 'Search', true)}</Provider>
+      );
 
-      expect(
-        result.getByText('Buscar')
-      ).toBeInTheDocument();
+      expect(result.getByText('Buscar')).toBeInTheDocument();
 
-      const translationKeysChangeArguments = [{
-        language: 'es',
-        value: 'Busqueda',
-        key: 'Search',
-        context: {
-          id: 'System',
-          label: 'System',
+      const translationKeysChangeArguments = [
+        {
+          language: 'es',
+          value: 'Busqueda',
+          key: 'Search',
+          context: {
+            id: 'System',
+            label: 'System',
+          },
         },
-      }];
+      ];
 
       await act(async () => {
         //@ts-ignore
@@ -120,9 +121,7 @@ describe('t function', () => {
       });
 
       await act(async () => {
-        expect(
-          result.getByText('Busqueda')
-        ).toBeInTheDocument();
+        expect(result.getByText('Busqueda')).toBeInTheDocument();
       });
     });
   });

--- a/app/react/I18N/specs/translateFunction.spec.tsx
+++ b/app/react/I18N/specs/translateFunction.spec.tsx
@@ -6,9 +6,9 @@ import { Provider } from 'jotai';
 import { act, render, RenderResult } from '@testing-library/react';
 import { localeAtom, translationsAtom, atomStore } from 'V2/atoms';
 import { socket } from 'app/socket';
+import 'app/App/sockets';
 import { t } from '../translateFunction';
 import { translations } from './fixtures';
-import 'app/App/sockets';
 
 describe('t function', () => {
   let renderResult: RenderResult;
@@ -71,7 +71,7 @@ describe('t function', () => {
             label: 'System',
             values: {
               Search: 'Buscar',
-              confirmDeleteDocument: '¿CONFIRMA b ELIMINACION?'
+              confirmDeleteDocument: '¿CONFIRMA ELIMINACION?'
             },
           },
         ],
@@ -84,7 +84,7 @@ describe('t function', () => {
 
       await act(async () => {
         expect(
-          result.getByText('¿CONFIRMA b ELIMINACION?')
+          result.getByText('¿CONFIRMA ELIMINACION?')
         ).toBeInTheDocument();
       });
     });

--- a/app/react/I18N/specs/translateFunction.spec.tsx
+++ b/app/react/I18N/specs/translateFunction.spec.tsx
@@ -2,11 +2,13 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { act, render, RenderResult } from '@testing-library/react';
 import { Provider } from 'jotai';
+import { act, render, RenderResult } from '@testing-library/react';
 import { localeAtom, translationsAtom, atomStore } from 'V2/atoms';
+import { socket } from 'app/socket';
 import { t } from '../translateFunction';
-import { translations, updatedTranslations } from './fixtures';
+import { translations } from './fixtures';
+import 'app/App/sockets';
 
 describe('t function', () => {
   let renderResult: RenderResult;
@@ -19,7 +21,6 @@ describe('t function', () => {
   beforeEach(() => {
     atomStore.set(translationsAtom, translations);
     atomStore.set(localeAtom, locale);
-    jest.spyOn(atomStore, 'sub');
     locale = 'es';
   });
 
@@ -32,12 +33,10 @@ describe('t function', () => {
     expect(
       renderResult.getByText('¿Esta seguro que quiere borrar este documento?')
     ).toBeInTheDocument();
-    expect(atomStore.sub).toHaveBeenCalledTimes(3);
-    expect(t.translation).toBe(undefined);
   });
 
   describe('no component', () => {
-    it('should return the translated string and subscribe to the atom store', () => {
+    it('should return the translated string', () => {
       renderEnvironment(
         'System',
         'confirmDeleteDocument',
@@ -47,32 +46,84 @@ describe('t function', () => {
       expect(
         renderResult.getByText('¿Esta seguro que quiere borrar este documento?')
       ).toBeInTheDocument();
-      // expect(atomStore.sub).toHaveBeenCalledTimes(4);
-      // expect(t.translation).toEqual({
-      //   contexts: translations[1].contexts,
-      //   locale: 'es',
-      // });
     });
 
-    it('should update translation when the atom updates', async () => {
-      renderEnvironment(
-        'System',
-        'confirmDeleteDocument',
-        'Are you sure you want to delete this document?',
-        false
-      );
-      expect(
-        renderResult.getByText('¿Esta seguro que quiere borrar este documento?')
-      ).toBeInTheDocument();
-
+    it('should update translation when the atom is updated partially from the socket', async () => {
       await act(async () => {
-        atomStore.set(translationsAtom, updatedTranslations);
+        atomStore.set(translationsAtom, [...translations]);
       });
 
-      // expect(t.translation).toEqual({
-      //   contexts: updatedTranslations[1].contexts,
-      //   locale: 'es',
-      // });
+      const result = render(<Provider store={atomStore}> {
+        t('System',
+          'confirmDeleteDocument',
+          'Are you sure you want to delete this document?', true)
+      }</Provider >);
+
+      expect(
+        result.getByText('¿Esta seguro que quiere borrar este documento?')
+      ).toBeInTheDocument();
+
+      const translation = {
+        locale: 'es',
+        contexts: [
+          {
+            id: 'System',
+            label: 'System',
+            values: {
+              Search: 'Buscar',
+              confirmDeleteDocument: '¿CONFIRMA b ELIMINACION?'
+            },
+          },
+        ],
+      };
+
+      await act(async () => {
+        //@ts-ignore
+        socket._callbacks.$translationsChange[0](translation);
+      });
+
+      await act(async () => {
+        expect(
+          result.getByText('¿CONFIRMA b ELIMINACION?')
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should update translation when the atom is updated fully from the socket', async () => {
+      await act(async () => {
+        atomStore.set(translationsAtom, [...translations]);
+      });
+
+      const result = render(<Provider store={atomStore}> {
+        t('System',
+          'Search',
+          'Search', true)
+      }</Provider >);
+
+      expect(
+        result.getByText('Buscar')
+      ).toBeInTheDocument();
+
+      const translationKeysChangeArguments = [{
+        language: 'es',
+        value: 'Busqueda',
+        key: 'Search',
+        context: {
+          id: 'System',
+          label: 'System',
+        },
+      }];
+
+      await act(async () => {
+        //@ts-ignore
+        socket._callbacks.$translationKeysChange[0](translationKeysChangeArguments);
+      });
+
+      await act(async () => {
+        expect(
+          result.getByText('Busqueda')
+        ).toBeInTheDocument();
+      });
     });
   });
 

--- a/app/react/I18N/translateFunction.tsx
+++ b/app/react/I18N/translateFunction.tsx
@@ -6,19 +6,7 @@ import { Translate } from './Translate';
 //return type as any since there is no way to create conditional returns based on parameters
 interface TranslationFunction {
   (contextId?: string, key?: string, text?: string | null, returnComponent?: boolean): any;
-  translation?: string;
 }
-
-// const updateTranslations = () => {
-//   const translations = atomStore.get(translationsAtom);
-//   const locale = atomStore.get(localeAtom);
-//   t.translation = getLocaleTranslation(translations, locale);
-//   return { translations, locale };
-// };
-//
-// atomStore.sub(translationsAtom, () => {
-//   updateTranslations();
-// });
 
 const t: TranslationFunction = (contextId, key, text, returnComponent = true) => {
   if (!contextId) {
@@ -29,8 +17,6 @@ const t: TranslationFunction = (contextId, key, text, returnComponent = true) =>
   if (returnComponent) {
     return <Translate context={contextId}>{key}</Translate>;
   }
-
-  // updateTranslations();
 
   const translations = atomStore.get(translationsAtom);
   const locale = atomStore.get(localeAtom);

--- a/app/react/V2/atoms/store.ts
+++ b/app/react/V2/atoms/store.ts
@@ -69,7 +69,7 @@ if (isClient && window.__atomStoreData__) {
   });
   atomStore.sub(translationsAtom, () => {
     const value = atomStore.get(translationsAtom);
-    store?.dispatch({ type: 'translations', value });
+    store?.dispatch({ type: 'translations/SET', value });
   });
 }
 


### PR DESCRIPTION
#6569 implemented a synchronization between the Redux State and the new state management of Jotai, however, the set function of atomStore doesn't recognize changes in the object array in-depth, which is solved through the destructuration of the updated values. Changes include:

- Set destructured translations
- Update translateFunction tests triggering socket events   
- Removes commented code from fix at #7684