### PR TITLE
Sentry error handling tweaks

### DIFF
--- a/app/api/utils/error_handling_middleware.js
+++ b/app/api/utils/error_handling_middleware.js
@@ -1,13 +1,7 @@
-import * as Sentry from '@sentry/node';
-import { config } from 'api/config';
 import { handleError } from './handleError';
 
 export default (error, req, res, next) => {
   const { message, code, ...rest } = handleError(error, { req });
-
-  if (config.sentry.dsn && code >= 500) {
-    Sentry.captureException(error);
-  }
 
   res.status(code);
   res.json({ error: message, ...rest });

--- a/app/api/utils/handleError.js
+++ b/app/api/utils/handleError.js
@@ -1,6 +1,8 @@
+import * as Sentry from '@sentry/node';
 import Ajv from 'ajv';
 import { UnauthorizedError } from 'api/authorization.v2/errors/UnauthorizedError';
 import { ValidationError } from 'api/common.v2/validation/ValidationError';
+import { config } from 'api/config';
 import { FileNotFound } from 'api/files/FileNotFound';
 import { S3Error } from 'api/files/S3Storage';
 import { legacyLogger } from 'api/log';
@@ -120,6 +122,7 @@ const prettifyError = (error, { req = {}, uncaught = false } = {}) => {
     : fallbackPrettifier(result, obfuscatedRequest);
 
   result.code = result.code || 500;
+  result.logLevel = result.logLevel || 'error';
   return result;
 };
 
@@ -185,6 +188,10 @@ const handleError = (_error, { req = {}, uncaught = false, useContext = true } =
   sendLog(result, error, {});
 
   result = simplifyError(result, error);
+
+  if (config.sentry.dsn && result.logLevel === 'error') {
+    Sentry.captureException(error);
+  }
 
   return result;
 };

--- a/app/api/utils/specs/error_handling_middleware.spec.js
+++ b/app/api/utils/specs/error_handling_middleware.spec.js
@@ -23,6 +23,7 @@ describe('Error handling middleware', () => {
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({
       error: 'error',
+      logLevel: 'error',
       prettyMessage: '\nerror',
       requestId: contextRequestId,
     });

--- a/app/api/utils/specs/handleError.spec.js
+++ b/app/api/utils/specs/handleError.spec.js
@@ -129,6 +129,11 @@ original error: {
     });
   });
 
+  it('should have a default "error" logLevel', () => {
+    const error = handleError({ message: 'error' });
+    expect(error.logLevel).toBe('error');
+  });
+
   describe('when error is uncaught', () => {
     it('should append the info into the message', () => {
       const uncaught = true;

--- a/app/server.js
+++ b/app/server.js
@@ -77,7 +77,9 @@ const http = Server(app);
 
 const uncaughtError = error => {
   handleError(error, { uncaught: true });
-  process.exit(1);
+  Sentry.close(2000).then(() => {
+    process.exit(1);
+  });
 };
 
 process.on('unhandledRejection', uncaughtError);


### PR DESCRIPTION
Sentry now will have enough time to capture error when unhandled error occurs, before forcing process exit.

Sentry is now capturing errors on the handleError function instead of the express middleware, some async processes use handleError directly.