### PR TITLE
withTransactions flaky tests fix

### DIFF
--- a/app/api/utils/AppContext.ts
+++ b/app/api/utils/AppContext.ts
@@ -17,7 +17,7 @@ class AppContext {
     return data;
   }
 
-  async run(cb: () => Promise<void>, data: ContextData = {}): Promise<void> {
+  async run<T>(cb: () => Promise<T>, data: ContextData = {}): Promise<T> {
     return new Promise((resolve, reject) => {
       this.storage.run({ ...this.defaultData, ...data }, () => {
         cb().then(resolve).catch(reject);

--- a/app/api/utils/specs/withTransaction.spec.ts
+++ b/app/api/utils/specs/withTransaction.spec.ts
@@ -124,15 +124,19 @@ describe('withTransaction utility', () => {
 
   it('should handle concurrent transactions', async () => {
     await appContext.run(async () => {
-      const transaction1 = withTransaction(async () => {
-        await model.save({ title: 'concurrent1', value: 1 });
-        return 'tx1';
-      });
+      const transaction1 = appContext.run(async () =>
+        withTransaction(async () => {
+          await model.save({ title: 'concurrent1', value: 1 });
+          return 'tx1';
+        })
+      );
 
-      const transaction2 = withTransaction(async () => {
-        await model.save({ title: 'concurrent2', value: 2 });
-        return 'tx2';
-      });
+      const transaction2 = appContext.run(async () =>
+        withTransaction(async () => {
+          await model.save({ title: 'concurrent2', value: 2 });
+          return 'tx2';
+        })
+      );
 
       const [result1, result2] = await Promise.all([transaction1, transaction2]);
       expect(result1).toBe('tx1');


### PR DESCRIPTION
fixes #7698 
withTransaction uses asyncContext to share the mongo session with the current async execution, while this works in production because only one transaction is performed per request, while testing it is needed to isolate the async contexts
