### PR TITLE
V1 and V2 db transactions compatibility

### DIFF
--- a/app/api/common.v2/database/MongoTransactionManager.ts
+++ b/app/api/common.v2/database/MongoTransactionManager.ts
@@ -35,8 +35,10 @@ export class MongoTransactionManager implements TransactionManager {
 
   private async commitWithRetry() {
     try {
-      await this.session!.commitTransaction();
-      this.finished = true;
+      if (!this.finished) {
+        await this.session!.commitTransaction();
+        this.finished = true;
+      }
     } catch (error) {
       if (error.hasErrorLabel && error.hasErrorLabel('UnknownTransactionCommitResult')) {
         this.logger.debug(error);
@@ -81,6 +83,14 @@ export class MongoTransactionManager implements TransactionManager {
 
       throw error;
     }
+  }
+
+  // for v1 compatibility
+  async abort() {
+    if (this.session?.inTransaction()) {
+      await this.session.abortTransaction();
+    }
+    this.finished = true;
   }
 
   async run<T>(callback: () => Promise<T>) {

--- a/app/api/common.v2/database/data_source_defaults.ts
+++ b/app/api/common.v2/database/data_source_defaults.ts
@@ -1,10 +1,15 @@
 import { DefaultLogger } from 'api/log.v2/infrastructure/StandardLogger';
+import { dbSessionContext } from 'api/odm/sessionsContext';
 import { IdGenerator } from '../contracts/IdGenerator';
 import { getClient } from './getConnectionForCurrentTenant';
 import { MongoIdHandler } from './MongoIdGenerator';
 import { MongoTransactionManager } from './MongoTransactionManager';
 
 const DefaultTransactionManager = () => {
+  const v1withTransactionStoredManager = dbSessionContext.getTransactionManager();
+  if (v1withTransactionStoredManager) {
+    return v1withTransactionStoredManager;
+  }
   const client = getClient();
   const logger = DefaultLogger();
   return new MongoTransactionManager(client, logger);

--- a/app/api/odm/sessionsContext.ts
+++ b/app/api/odm/sessionsContext.ts
@@ -1,11 +1,10 @@
 import { ClientSession } from 'mongoose';
 import { Readable } from 'stream';
 
-import { tenants } from 'api/tenants';
 import { appContext } from 'api/utils/AppContext';
 
-import { DB } from './DB';
 import { FileTypes } from 'api/files/storage';
+import { MongoTransactionManager } from 'api/common.v2/database/MongoTransactionManager';
 
 export const dbSessionContext = {
   getSession() {
@@ -30,6 +29,7 @@ export const dbSessionContext = {
   },
 
   clearSession() {
+    appContext.set('transactionManager', undefined);
     appContext.set('mongoSession', undefined);
   },
 
@@ -37,13 +37,20 @@ export const dbSessionContext = {
     appContext.set('mongoSession', undefined);
     appContext.set('reindexOperations', undefined);
     appContext.set('fileOperations', undefined);
+    appContext.set('transactionManager', undefined);
   },
 
-  async startSession() {
-    const currentTenant = tenants.current();
-    const session = DB.connectionForDB(currentTenant.dbName).getClient().startSession();
+  getTransactionManager() {
+    return appContext.get('transactionManager') as MongoTransactionManager | undefined;
+  },
+
+  setTransactionManager(transactionManager: MongoTransactionManager) {
+    appContext.set('mongoSession', transactionManager.getSession());
+    appContext.set('transactionManager', transactionManager);
+  },
+
+  setSession(session: ClientSession) {
     appContext.set('mongoSession', session);
-    return session;
   },
 
   registerESIndexOperation(args: [query?: any, select?: string, limit?: number]) {

--- a/app/api/utils/specs/withTransaction.spec.ts
+++ b/app/api/utils/specs/withTransaction.spec.ts
@@ -185,6 +185,7 @@ describe('withTransaction utility', () => {
       });
 
       expect(dbSessionContext.getSession()).toBeUndefined();
+      expect(dbSessionContext.getTransactionManager()).toBeUndefined();
       expect(dbSessionContext.getFileOperations()).toEqual([]);
       expect(dbSessionContext.getReindexOperations()).toEqual([]);
     });

--- a/app/api/utils/testingEnvironment.ts
+++ b/app/api/utils/testingEnvironment.ts
@@ -33,7 +33,12 @@ const testingEnvironment = {
     if (!jest.isMockFunction(appContext.get)) {
       const originalAppContextGet = appContext.get.bind(appContext);
       appContextGetMock = jest.spyOn(appContext, 'get').mockImplementation((key: string) => {
-        if (key === 'mongoSession' || key === 'fileOperations' || key === 'reindexOperations') {
+        if (
+          key === 'mongoSession' ||
+          key === 'fileOperations' ||
+          key === 'reindexOperations' ||
+          key === 'transactionManager'
+        ) {
           return undefined;
         }
         return originalAppContextGet(key);

--- a/app/api/utils/withTransaction.ts
+++ b/app/api/utils/withTransaction.ts
@@ -1,3 +1,4 @@
+import { DefaultTransactionManager } from 'api/common.v2/database/data_source_defaults';
 import { storage } from 'api/files/storage';
 import { DefaultLogger } from 'api/log.v2/infrastructure/StandardLogger';
 import { dbSessionContext } from 'api/odm/sessionsContext';
@@ -45,52 +46,40 @@ const withTransaction = async <T>(
   const startTime = performance.now();
   const logNamespace = namespace ? `(${namespace})` : '';
 
-  const session = await dbSessionContext.startSession();
-  session.startTransaction();
+  const transactionManager = DefaultTransactionManager();
+
   let wasManuallyAborted = false;
-
-  const context: TransactionOperation = {
-    abort: async () => {
-      if (session.inTransaction()) {
-        await session.abortTransaction();
-      }
-      wasManuallyAborted = true;
-
-      if (process.env.NODE_ENV !== 'test') {
-        const elapsedTime = performance.now() - startTime;
-        logger.info(
-          `[v1_transactions] Transactions ${logNamespace} was manually aborted,` +
-            ` session id -> ${inspect(session.id)} (${elapsedTime.toFixed(2)}ms)`
-        );
-      }
-    },
-  };
-
   try {
-    const result = await operation(context);
+    return await transactionManager.run(async () => {
+      dbSessionContext.setTransactionManager(transactionManager);
+      const context: TransactionOperation = {
+        abort: async () => {
+          await transactionManager.abort();
+          wasManuallyAborted = true;
 
+          if (process.env.NODE_ENV !== 'test') {
+            const elapsedTime = performance.now() - startTime;
+            logger.info(
+              `[v1_transactions] Transactions ${logNamespace} was manually aborted,` +
+                ` session id -> ${inspect(transactionManager.getSession()?.id)} (${elapsedTime.toFixed(2)}ms)`
+            );
+          }
+        },
+      };
+      try {
+        return await operation(context);
+      } finally {
+        if (!wasManuallyAborted) {
+          dbSessionContext.clearSession();
+          await performDelayedFileStores();
+        }
+      }
+    });
+  } finally {
     if (!wasManuallyAborted) {
-      dbSessionContext.clearSession();
-      await performDelayedFileStores();
-      await session.commitTransaction();
       await performDelayedReindexes();
     }
-    return result;
-  } catch (e) {
-    if (!wasManuallyAborted) {
-      if (process.env.NODE_ENV !== 'test') {
-        const errorTime = performance.now() - startTime;
-        logger.info(
-          `[v1_transactions] Transaction ${logNamespace} aborted due to error: ${inspect(e)},` +
-            ` session id -> ${inspect(session.id)} (${errorTime.toFixed(2)}ms)`
-        );
-      }
-      await session.abortTransaction();
-    }
-    throw e;
-  } finally {
     dbSessionContext.clearContext();
-    await session.endSession();
   }
 };
 


### PR DESCRIPTION
This solves the problem of old endpoints using withTransactions that also combine v2 functionality, the mongo session
is now shared with V2 arquitecture when using v1 transactions in an old endpoint.