### PR TITLE
Revert segmentations retry

### DIFF
--- a/app/api/services/informationextraction/specs/InformationExtraction.spec.ts
+++ b/app/api/services/informationextraction/specs/InformationExtraction.spec.ts
@@ -948,7 +948,6 @@ describe('InformationExtraction', () => {
         fileID: factory.id('F1'),
         filename: 'documentA.pdf',
         status: 'failed',
-        retryCount: 1,
       });
 
       // Segmentation with ready status for documentC
@@ -1046,14 +1045,12 @@ describe('InformationExtraction', () => {
         fileID: factory.id('F1'),
         filename: 'documentA.pdf',
         status: 'failed',
-        retryCount: 1,
       });
 
       await SegmentationModel.save({
         fileID: factory.id('F2'),
         filename: 'documentB.pdf',
         status: 'failed',
-        retryCount: 2,
       });
 
       await informationExtraction.getSuggestions(factory.id('prop1extractor'));
@@ -1219,7 +1216,6 @@ describe('InformationExtraction', () => {
         fileID: factory.id('F1'),
         filename: 'documentA.pdf',
         status: 'failed',
-        retryCount: 1,
       });
 
       await SegmentationModel.save({
@@ -1269,7 +1265,6 @@ describe('InformationExtraction', () => {
         fileID: factory.id('F3'),
         filename: 'documentC.pdf',
         status: 'failed',
-        retryCount: 1,
       });
 
       await informationExtraction.getSuggestions(factory.id('prop1extractor'));
@@ -1308,7 +1303,6 @@ describe('InformationExtraction', () => {
         fileID: factory.id('F1'),
         filename: 'document1.pdf',
         status: 'failed',
-        retryCount: 1,
       });
 
       await SegmentationModel.save({
@@ -1377,6 +1371,7 @@ describe('InformationExtraction', () => {
     });
 
     it('should create suggestions for all files regardless of segmentation status', async () => {
+      // Segmentations with different statuses
       await SegmentationModel.save({
         fileID: factory.id('F1'),
         filename: 'documentA.pdf',
@@ -1395,7 +1390,6 @@ describe('InformationExtraction', () => {
         fileID: factory.id('F3'),
         filename: 'documentC.pdf',
         status: 'failed',
-        retryCount: 1,
       });
 
       await informationExtraction.getSuggestions(factory.id('prop1extractor'));

--- a/app/api/services/pdfsegmentation/PDFSegmentation.ts
+++ b/app/api/services/pdfsegmentation/PDFSegmentation.ts
@@ -17,7 +17,6 @@ import { SegmentationModel } from './segmentationModel';
 
 class PDFSegmentation {
   static SERVICE_NAME = 'segmentation';
-  static MAX_RETRY_COUNT = 3;
 
   public segmentationTaskManager: TaskManager;
 
@@ -69,93 +68,33 @@ class PDFSegmentation {
     }
   };
 
-  storeProcess = async (fileID: ObjectIdSchema, filename: string, processing = true) => {
-    const [existingSegmentation] = await SegmentationModel.get({ fileID });
-
-    if (existingSegmentation) {
-      if (
-        existingSegmentation.status === 'failed' &&
-        (existingSegmentation.retryCount || 0) >= PDFSegmentation.MAX_RETRY_COUNT
-      ) {
-        return;
-      }
-      await SegmentationModel.save({
-        ...existingSegmentation,
-        status: processing ? 'processing' : 'failed',
-        retryCount: processing ? 0 : (existingSegmentation.retryCount || 0) + 1,
-      });
-    } else {
-      await SegmentationModel.save({
-        fileID,
-        filename,
-        status: processing ? 'processing' : 'failed',
-        retryCount: processing ? 0 : 1,
-      });
-    }
-  };
+  storeProcess = async (fileID: ObjectIdSchema, filename: string, processing = true) =>
+    SegmentationModel.save({
+      fileID,
+      filename,
+      status: processing ? 'processing' : 'failed',
+    });
 
   getFilesToSegment = async (): Promise<{ filename: string; _id: ObjectIdSchema }[]> => {
-    const segmentations = (await SegmentationModel.get({
-      fileID: { $exists: true },
-    })) as SegmentationType[];
+    const segmentations = (await SegmentationModel.get(
+      { fileID: { $exists: true } },
+      'fileID'
+    )) as (SegmentationType & { fileID: string })[];
 
-    const successfullySegmentedFiles = segmentations
-      .filter(segmentation => segmentation.status === 'ready')
-      .map(segmentation => segmentation.fileID);
-
-    const processingFiles = segmentations
-      .filter(segmentation => segmentation.status === 'processing')
-      .map(segmentation => segmentation.fileID);
-
-    const permanentlyFailedSegmentedFiles = segmentations
-      .filter(
-        segmentation =>
-          segmentation.status === 'failed' &&
-          (segmentation.retryCount || 0) >= PDFSegmentation.MAX_RETRY_COUNT
-      )
-      .map(segmentation => segmentation.fileID);
-
-    const retryableFailedSegmentations = segmentations.filter(
-      segmentation =>
-        segmentation.status === 'failed' &&
-        (segmentation.retryCount || 0) < PDFSegmentation.MAX_RETRY_COUNT
-    );
+    const segmentedFiles = segmentations.map(segmentation => segmentation.fileID);
 
     const files = (await filesModel.get(
       {
         type: 'document',
         filename: { $exists: true },
         status: 'ready',
-        _id: {
-          $nin: [
-            ...successfullySegmentedFiles,
-            ...processingFiles,
-            ...permanentlyFailedSegmentedFiles,
-          ],
-        },
+        _id: { $nin: segmentedFiles },
       },
       'filename',
       { limit: this.batchSize }
     )) as (FileType & { filename: string; _id: ObjectIdSchema })[];
 
-    const allFilesToProcess = [
-      ...files.map(file => ({ _id: file._id, filename: file.filename })),
-      ...retryableFailedSegmentations
-        .filter(
-          segmentation =>
-            segmentation.fileID &&
-            segmentation.filename &&
-            !processingFiles.includes(segmentation.fileID)
-        )
-        .map(segmentation => ({
-          _id: segmentation.fileID!,
-          filename: segmentation.filename!,
-          status: segmentation.status,
-          retryCount: segmentation.retryCount,
-        })),
-    ];
-
-    return allFilesToProcess;
+    return files.map(file => ({ _id: file._id, filename: file.filename }));
   };
 
   segmentPdfs = async () => {
@@ -233,13 +172,11 @@ class PDFSegmentation {
   saveSegmentationError = async (filename: string) => {
     const [segmentation] = await SegmentationModel.get({ filename });
     if (segmentation) {
-      const currentRetryCount = segmentation.retryCount || 0;
       await SegmentationModel.save({
         ...segmentation,
         filename,
         autoexpire: null,
         status: 'failed',
-        retryCount: currentRetryCount + 1,
       });
     }
   };

--- a/app/api/services/pdfsegmentation/segmentationModel.ts
+++ b/app/api/services/pdfsegmentation/segmentationModel.ts
@@ -6,7 +6,6 @@ const props = {
   autoexpire: { type: Date, expires: 86400, default: Date.now }, // 24 hours
   fileID: { type: mongoose.Schema.Types.ObjectId, ref: 'File' },
   status: { type: String, enum: ['processing', 'failed', 'ready'], default: 'processing' },
-  retryCount: { type: Number, default: 0 },
 };
 
 const mongoSchema = new mongoose.Schema(props, {

--- a/app/api/services/pdfsegmentation/specs/PDFSegmentation.spec.ts
+++ b/app/api/services/pdfsegmentation/specs/PDFSegmentation.spec.ts
@@ -11,7 +11,6 @@ import {
   fixturesOneHundredFiles,
   fixturesFiveFiles,
   fixturesMissingPdf,
-  fixturesWithFailedSegmentations,
 } from 'api/services/pdfsegmentation/specs/fixtures';
 
 import { storage } from 'api/files';
@@ -164,139 +163,7 @@ describe('PDFSegmentation', () => {
 
     await segmentPdfs.segmentPdfs();
 
-    // With batch size 50, should process 4 files: 3 ready files (F2, F3, F4, F5) + 1 failed file (F6) for retry
-    // The processing file (F1) is excluded
     expect(segmentPdfs.segmentationTaskManager?.startTask).toHaveBeenCalledTimes(4);
-  });
-
-  it('should retry failed segmentations', async () => {
-    await fixturer.clearAllAndLoad(dbOne, fixturesWithFailedSegmentations);
-
-    await dbOne.collection('segmentations').insertMany([
-      {
-        _id: testingDB.id(),
-        fileID: fixturesWithFailedSegmentations.files![0]._id,
-        filename: 'document1.pdf',
-        status: 'failed',
-      },
-      {
-        _id: testingDB.id(),
-        fileID: fixturesWithFailedSegmentations.files![1]._id,
-        filename: 'document2.pdf',
-        status: 'ready',
-      },
-    ]);
-
-    segmentPdfs.segmentationTaskManager!.countPendingTasks = async () => Promise.resolve(0);
-
-    await segmentPdfs.segmentPdfs();
-
-    // Since the files don't exist in storage, they should be marked as failed
-    // The startTask should not be called because the files are not found
-    expect(segmentPdfs.segmentationTaskManager?.startTask).toHaveBeenCalledTimes(0);
-
-    // Verify that the failed segmentation records were deleted and new failed ones were created
-    await tenants.run(async () => {
-      const segmentations = await SegmentationModel.get();
-
-      // Should have segmentations for the files that were processed
-      expect(segmentations.length).toBeGreaterThanOrEqual(2);
-
-      // Should have failed segmentations for the files that don't exist
-      const failedSegmentations = segmentations.filter(s => s.status === 'failed');
-      expect(failedSegmentations.length).toBeGreaterThanOrEqual(2);
-
-      // Should have the original successful segmentation
-      const successfulSegmentations = segmentations.filter(s => s.status === 'ready');
-      expect(successfulSegmentations.length).toBeGreaterThanOrEqual(1);
-    }, 'tenantOne');
-  });
-
-  it('should retry failed segmentations with existing files', async () => {
-    await fixturer.clearAllAndLoad(dbOne, fixturesFiveFiles);
-
-    await dbOne.collection('segmentations').insertMany([
-      {
-        _id: testingDB.id(),
-        fileID: fixturesFiveFiles.files![0]._id,
-        filename: fixturesFiveFiles.files![0].filename,
-        status: 'failed',
-      },
-      {
-        _id: testingDB.id(),
-        fileID: fixturesFiveFiles.files![1]._id,
-        filename: fixturesFiveFiles.files![1].filename,
-        status: 'ready',
-      },
-    ]);
-
-    segmentPdfs.segmentationTaskManager!.countPendingTasks = async () => Promise.resolve(0);
-
-    await segmentPdfs.segmentPdfs();
-
-    // With batch size 50, should process 5 files: 2 failed files for retry (F1 + F6) + 3 new files (F3, F4, F5)
-    // The ready file (F2) should be excluded
-    expect(segmentPdfs.segmentationTaskManager?.startTask).toHaveBeenCalledTimes(5);
-
-    // Verify that the failed segmentation records were deleted
-    await tenants.run(async () => {
-      const segmentations = await SegmentationModel.get();
-
-      // Should have segmentations for the files that were processed
-      expect(segmentations.length).toBeGreaterThanOrEqual(5);
-
-      // Should not have any failed segmentations (they were deleted for retry)
-      const failedSegmentations = segmentations.filter(s => s.status === 'failed');
-      expect(failedSegmentations.length).toBe(0);
-
-      // Should have the original successful segmentation
-      const successfulSegmentations = segmentations.filter(s => s.status === 'ready');
-      expect(successfulSegmentations.length).toBeGreaterThanOrEqual(1);
-    }, 'tenantOne');
-  });
-
-  it('should not retry failed segmentations that have exceeded the retry limit', async () => {
-    await fixturer.clearAllAndLoad(dbOne, fixturesFiveFiles);
-
-    // Insert a segmentation that has exceeded the retry limit
-    await dbOne.collection('segmentations').insertMany([
-      {
-        _id: testingDB.id(),
-        fileID: fixturesFiveFiles.files![0]._id,
-        filename: fixturesFiveFiles.files![0].filename,
-        status: 'failed',
-        retryCount: 3, // Max retry count reached
-      },
-      {
-        _id: testingDB.id(),
-        fileID: fixturesFiveFiles.files![1]._id,
-        filename: fixturesFiveFiles.files![1].filename,
-        status: 'ready',
-      },
-    ]);
-
-    segmentPdfs.segmentationTaskManager!.countPendingTasks = async () => Promise.resolve(0);
-
-    await segmentPdfs.segmentPdfs();
-
-    // Should process 3 files: 3 ready files (F3, F4, F5)
-    // The maxed-out failed file and the ready file should be excluded
-    expect(segmentPdfs.segmentationTaskManager?.startTask).toHaveBeenCalledTimes(3);
-
-    // Verify that the maxed-out failed segmentation was not processed
-    await tenants.run(async () => {
-      const segmentations = await SegmentationModel.get();
-
-      // Should have the maxed-out failed segmentation still present (unchanged)
-      const maxedOutFailedSegmentations = segmentations.filter(
-        s => s.status === 'failed' && s.retryCount === 3
-      );
-      expect(maxedOutFailedSegmentations.length).toBe(1);
-
-      // Should have the original successful segmentation
-      const successfulSegmentations = segmentations.filter(s => s.status === 'ready');
-      expect(successfulSegmentations.length).toBeGreaterThanOrEqual(1);
-    }, 'tenantOne');
   });
 
   describe('if the file is missing', () => {
@@ -438,66 +305,8 @@ describe('PDFSegmentation', () => {
           expect(segmentation.filename).toBe(fixturesPdfNameA);
           expect(segmentation.fileID).toEqual(fixturesOneFile.files![0]._id);
           expect(segmentation.autoexpire).toBe(null);
-          expect(segmentation.retryCount).toBe(1);
           expect(segmentations.length).toBe(1);
         }, tenantOne.name);
-      });
-
-      it('should increment retry count on subsequent failures', async () => {
-        await segmentPdfs.processResults({
-          tenant: tenantOne.name,
-          params: { filename: 'documentA.pdf' },
-          data_url: 'http://localhost:1235/results',
-          file_url: 'http://localhost:1235/file',
-          task: 'segmentation',
-          success: false,
-        });
-
-        await segmentPdfs.processResults({
-          tenant: tenantOne.name,
-          params: { filename: 'documentA.pdf' },
-          data_url: 'http://localhost:1235/results',
-          file_url: 'http://localhost:1235/file',
-          task: 'segmentation',
-          success: false,
-        });
-
-        await tenants.run(async () => {
-          const segmentations = await SegmentationModel.get();
-          const [segmentation] = segmentations;
-          expect(segmentation.status).toBe('failed');
-          expect(segmentation.filename).toBe(fixturesPdfNameA);
-          expect(segmentation.retryCount).toBe(2);
-          expect(segmentations.length).toBe(1);
-        }, tenantOne.name);
-      });
-
-      it('should not create duplicate entries when retrying failed segmentations', async () => {
-        await fixturer.clearAllAndLoad(dbOne, fixturesOneFile);
-
-        await tenants.run(async () => {
-          await SegmentationModel.save({
-            fileID: fixturesOneFile.files![0]._id,
-            filename: fixturesOneFile.files![0].filename,
-            status: 'failed',
-            retryCount: 0,
-          });
-        }, 'tenantOne');
-
-        // Now run segmentation to retry the failed file
-        segmentPdfs.segmentationTaskManager!.countPendingTasks = async () => Promise.resolve(0);
-        await segmentPdfs.segmentPdfs();
-
-        await tenants.run(async () => {
-          const segmentations = await SegmentationModel.get();
-
-          // Should have exactly one segmentation entry
-          expect(segmentations.length).toBe(1);
-
-          // Should be in processing status
-          expect(segmentations[0].status).toBe('processing');
-          expect(segmentations[0].filename).toBe(fixturesOneFile.files![0].filename);
-        }, 'tenantOne');
       });
     });
   });

--- a/app/shared/types/segmentationSchema.ts
+++ b/app/shared/types/segmentationSchema.ts
@@ -42,7 +42,6 @@ export const segmentationSchema = {
     filename: { type: 'string', minLength: 1 },
     xmlname: { type: 'string', minLength: 1 },
     status: { type: 'string', enum: ['processing', 'failed', 'ready'] },
-    retryCount: { type: 'number' },
     segmentation: {
       type: 'object',
       additionalProperties: false,

--- a/app/shared/types/segmentationType.d.ts
+++ b/app/shared/types/segmentationType.d.ts
@@ -22,7 +22,6 @@ export interface SegmentationType {
   filename?: string;
   xmlname?: string;
   status?: 'processing' | 'failed' | 'ready';
-  retryCount?: number;
   segmentation?: {
     page_width?: number;
     page_height?: number;


### PR DESCRIPTION
Revert changes from commit 1af0f85e6 that added retry count - Restores original simpler segmentation processing behavior - Addresses performance concerns on production servers

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
