### PR TITLE
References grouping explosion

### DIFF
--- a/app/react/Viewer/components/PageReferences.tsx
+++ b/app/react/Viewer/components/PageReferences.tsx
@@ -135,14 +135,12 @@ const groupByRectangle = createSelector(
 
       if (reference?.get('template') || !reference) return groups;
 
-      let hasGroup = false;
-
       const rectangles = reference.get('reference')?.get('selectionRectangles');
 
       if (!rectangles?.size) return groups;
 
-      groups?.forEach(refGroups => {
-        refGroups.forEach(refGroup => {
+      const hasGroup = groups?.some(refGroups =>
+        refGroups.some(refGroup => {
           if (
             refGroup.length === rectangles.size &&
             refGroup.start.page === rectangles.get(0).get('page') &&
@@ -150,20 +148,21 @@ const groupByRectangle = createSelector(
             refGroup.end.page === rectangles.get(rectangles.size - 1).get('page') &&
             refGroup.end.width === rectangles.get(rectangles.size - 1).get('width')
           ) {
-            hasGroup = true;
             refGroups.push({
               _id: reference.get('_id')!.toString(),
               length: rectangles.size,
               start: rectangles.get(0).toJS(),
               end: rectangles.get(rectangles.size - 1).toJS(),
             });
+            return true;
           }
-        });
-      });
+          return false;
+        })
+      );
 
       if (hasGroup) return groups;
 
-      groups!.push([
+      groups.push([
         {
           _id: reference.get('_id')!.toString(),
           length: rectangles.size,

--- a/app/react/Viewer/components/specs/PageReferences.spec.tsx
+++ b/app/react/Viewer/components/specs/PageReferences.spec.tsx
@@ -58,6 +58,11 @@ describe('FormConfigInput', () => {
           },
         },
         {
+          _id: '8',
+          entity: 'vhsj',
+          reference: { selectionRectangles: [{ page: '4', width: 100 }] },
+        },
+        {
           _id: '5',
           entity: 'ce87',
           reference: { selectionRectangles: [{ page: '3', width: 101 }] },
@@ -100,6 +105,7 @@ describe('FormConfigInput', () => {
       [{ _id: '1', length: 1, start: { page: '2' }, end: { page: '2' } }],
       [
         { _id: '6', length: 1, start: { page: '4', width: 100 }, end: { page: '4', width: 100 } },
+        { _id: '8', length: 1, start: { page: '4', width: 100 }, end: { page: '4', width: 100 } },
         { _id: '7', length: 1, start: { page: '4', width: 100 }, end: { page: '4', width: 100 } },
       ],
       [{ _id: '2', length: 1, start: { page: '3' }, end: { page: '3' } }],

--- a/app/react/Viewer/components/specs/PageReferences.spec.tsx
+++ b/app/react/Viewer/components/specs/PageReferences.spec.tsx
@@ -36,6 +36,11 @@ describe('FormConfigInput', () => {
       targetDocReferences: Immutable.fromJS([]),
       references: Immutable.fromJS([
         { _id: '1', entity: 'ab42', reference: { selectionRectangles: [{ page: '2' }] } },
+        {
+          _id: '6',
+          entity: 'df57',
+          reference: { selectionRectangles: [{ page: '4', width: 100 }] },
+        },
         { _id: '2', entity: 'ab42', reference: { selectionRectangles: [{ page: '3' }] } },
         {
           _id: '3',
@@ -56,11 +61,6 @@ describe('FormConfigInput', () => {
           _id: '5',
           entity: 'ce87',
           reference: { selectionRectangles: [{ page: '3', width: 101 }] },
-        },
-        {
-          _id: '6',
-          entity: 'df57',
-          reference: { selectionRectangles: [{ page: '4', width: 100 }] },
         },
         {
           _id: '7',
@@ -95,8 +95,13 @@ describe('FormConfigInput', () => {
 
   it('should group references with same selection rectangles', () => {
     const result = groupByRectangle(store.getState() as IStore);
+    JSON.stringify(result, null, 2);
     expect(result).toEqual([
       [{ _id: '1', length: 1, start: { page: '2' }, end: { page: '2' } }],
+      [
+        { _id: '6', length: 1, start: { page: '4', width: 100 }, end: { page: '4', width: 100 } },
+        { _id: '7', length: 1, start: { page: '4', width: 100 }, end: { page: '4', width: 100 } },
+      ],
       [{ _id: '2', length: 1, start: { page: '3' }, end: { page: '3' } }],
       [{ _id: '3', length: 2, start: { page: '3' }, end: { page: '4' } }],
       [
@@ -108,10 +113,6 @@ describe('FormConfigInput', () => {
         },
       ],
       [{ _id: '5', length: 1, start: { page: '3', width: 101 }, end: { page: '3', width: 101 } }],
-      [
-        { _id: '6', length: 1, start: { page: '4', width: 100 }, end: { page: '4', width: 100 } },
-        { _id: '7', length: 1, start: { page: '4', width: 100 }, end: { page: '4', width: 100 } },
-      ],
     ]);
   });
 


### PR DESCRIPTION
fixes issue with text references creating huge loops in some cases, making it impossible to load a document and crashing the client.

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
