### PR TITLE
Fix/revert testingEnvironment elastic config

### DIFF
--- a/app/api/utils/testingEnvironment.ts
+++ b/app/api/utils/testingEnvironment.ts
@@ -1,13 +1,10 @@
+import { setupTestUploadedPaths } from 'api/files';
 import { appContext } from 'api/utils/AppContext';
-import { DB } from 'api/odm';
+import { elasticTesting } from 'api/utils/elastic_testing';
 import testingDB, { DBFixture } from 'api/utils/testing_db';
 import { testingTenants } from 'api/utils/testingTenants';
-import { elasticTesting } from 'api/utils/elastic_testing';
 import { UserInContextMockFactory } from 'api/utils/testingUserInContext';
-import { setupTestUploadedPaths } from 'api/files';
 import { UserSchema } from 'shared/types/userType';
-import path from 'path';
-import uniqueID from 'shared/uniqueID';
 
 let appContextGetMock: jest.SpyInstance<unknown, [key: string], any>;
 let appContextSetMock: jest.SpyInstance<unknown, [key: string, value: unknown], any>;
@@ -24,16 +21,10 @@ const testingEnvironment = {
   },
 
   async setTenant(name?: string, subPath = '') {
-    const testPath = expect.getState().testPath || '';
-    const sanitizedTestPath = path.basename(testPath).replace(/[.-]/g, '_');
-    const defaultIndexName = `index_${uniqueID()}_${sanitizedTestPath}`
-      .substring(0, 63)
-      .toLowerCase();
-
     testingTenants.mockCurrentTenant({
       name: name || testingDB.dbName || 'defaultDB',
       dbName: testingDB.dbName || name || 'defaultDB',
-      indexName: defaultIndexName,
+      indexName: 'index',
     });
     await setupTestUploadedPaths(subPath);
   },
@@ -74,23 +65,7 @@ const testingEnvironment = {
   async setElastic(elasticIndex?: string) {
     if (elasticIndex) {
       testingTenants.changeCurrentTenant({ indexName: elasticIndex });
-      if (DB.getConnection()) {
-        await elasticTesting.reindex();
-      }
-      return;
-    }
-
-    // Ensure a unique default test index exists (guard against testingDB.connect() overriding tenant index)
-    const testPath = expect.getState().testPath || '';
-    const sanitizedTestPath = path.basename(testPath).replace(/[.-]/g, '_');
-    const defaultIndexName = `index_${uniqueID()}_${sanitizedTestPath}`
-      .substring(0, 63)
-      .toLowerCase();
-    testingTenants.changeCurrentTenant({ indexName: defaultIndexName });
-
-    // Create/reset mappings for the (now unique) index
-    if (DB.getConnection()) {
-      await elasticTesting.resetIndex();
+      await elasticTesting.reindex();
     }
   },
 

--- a/app/setUpJestServer.js
+++ b/app/setUpJestServer.js
@@ -9,18 +9,10 @@ mongoose.Promise = Promise;
 mongoose.set('autoIndex', false);
 
 afterAll(async () => {
-  try {
-    await elasticClient.close();
-  } catch (e) {
-    // ignore
-  }
+  await elasticClient.close();
 
-  try {
-    const client = Redis.redisClient;
-    if (client && client.connected) {
-      await Redis.disconnect();
-    }
-  } catch (e) {
-    // ignore
+  const client = Redis.redisClient;
+  if (client && client.connected) {
+    await Redis.disconnect();
   }
 });


### PR DESCRIPTION
Previous changes made every test to use an elastic index when only some
of the tests need one, increasing total execution by a considerable
amount and creating unnecessary es index, locally hitting more than the
default 1000 allowed indexes
