### PR TITLE
Stream errors killing the express server process

### DIFF
--- a/app/api/core/domain/files/FileContents.ts
+++ b/app/api/core/domain/files/FileContents.ts
@@ -1,33 +1,15 @@
-import { Readable } from 'stream';
-
 export type StreamCallback = () => AsyncIterable<Uint8Array>;
 
 export class FileContents {
   private streamCallback?: StreamCallback;
 
-  private _getReadable?: () => Promise<Readable>;
-
   constructor(streamCallback: StreamCallback) {
     this.streamCallback = streamCallback;
   }
 
-  setReadable(getReadable: () => Promise<Readable>) {
-    this._getReadable = getReadable;
-  }
-
-  async getReadable(): Promise<Readable> {
-    if (!this?._getReadable) {
-      throw new Error('Readable stream callback not defined');
-    }
-
-    return this._getReadable();
-  }
-
   async *read(): AsyncIterable<Uint8Array> {
     if (this.streamCallback) {
-      for await (const chunk of this.streamCallback()) {
-        yield chunk;
-      }
+      yield* this.streamCallback();
     }
   }
 }

--- a/app/api/core/domain/files/FileContents.ts
+++ b/app/api/core/domain/files/FileContents.ts
@@ -1,13 +1,26 @@
+import { Readable } from 'stream';
+
 export type StreamCallback = () => AsyncIterable<Uint8Array>;
 
 export class FileContents {
   private streamCallback?: StreamCallback;
 
-  private cleanup?: () => void;
+  private _getReadable?: () => Promise<Readable>;
 
-  constructor(streamCallback: StreamCallback, cleanup?: () => void) {
+  constructor(streamCallback: StreamCallback) {
     this.streamCallback = streamCallback;
-    this.cleanup = cleanup;
+  }
+
+  setGetReadable(getReadable: () => Promise<Readable>) {
+    this._getReadable = getReadable;
+  }
+
+  async getReadableAsync(): Promise<Readable> {
+    if (!this?._getReadable) {
+      throw new Error('Readable stream callback not defined');
+    }
+
+    return this._getReadable();
   }
 
   async *read(): AsyncIterable<Uint8Array> {
@@ -15,12 +28,6 @@ export class FileContents {
       for await (const chunk of this.streamCallback()) {
         yield chunk;
       }
-    }
-  }
-
-  destroy(): void {
-    if (this.cleanup) {
-      this.cleanup();
     }
   }
 }

--- a/app/api/core/domain/files/FileContents.ts
+++ b/app/api/core/domain/files/FileContents.ts
@@ -3,8 +3,11 @@ export type StreamCallback = () => AsyncIterable<Uint8Array>;
 export class FileContents {
   private streamCallback?: StreamCallback;
 
-  constructor(streamCallback: StreamCallback) {
+  private cleanup?: () => void;
+
+  constructor(streamCallback: StreamCallback, cleanup?: () => void) {
     this.streamCallback = streamCallback;
+    this.cleanup = cleanup;
   }
 
   async *read(): AsyncIterable<Uint8Array> {
@@ -12,6 +15,12 @@ export class FileContents {
       for await (const chunk of this.streamCallback()) {
         yield chunk;
       }
+    }
+  }
+
+  destroy(): void {
+    if (this.cleanup) {
+      this.cleanup();
     }
   }
 }

--- a/app/api/core/domain/files/FileContents.ts
+++ b/app/api/core/domain/files/FileContents.ts
@@ -11,11 +11,11 @@ export class FileContents {
     this.streamCallback = streamCallback;
   }
 
-  setGetReadable(getReadable: () => Promise<Readable>) {
+  setReadable(getReadable: () => Promise<Readable>) {
     this._getReadable = getReadable;
   }
 
-  async getReadableAsync(): Promise<Readable> {
+  async getReadable(): Promise<Readable> {
     if (!this?._getReadable) {
       throw new Error('Readable stream callback not defined');
     }

--- a/app/api/core/infrastructure/express/DownloadFileController.ts
+++ b/app/api/core/infrastructure/express/DownloadFileController.ts
@@ -1,4 +1,4 @@
-import { createError, handleError } from 'api/utils';
+import { createError } from 'api/utils';
 
 import { AbstractController, Dependencies } from 'api/common.v2/infrastructure/AbstractController';
 import { FileStorage } from 'api/core/application/contracts/FileStorage';
@@ -7,8 +7,8 @@ import { fileDBO } from 'api/core/infrastructure/mongodb/files/schemas/filesType
 import { tenants } from 'api/tenants';
 import { Request, Response } from 'express';
 import { FileType } from 'shared/types/fileType';
-import { Readable } from 'stream';
 import { z } from 'zod';
+import { pipeline } from 'stream/promises';
 import { FilesDataSourceFactory } from '../factories/FilesDataSourceFactory';
 import { SettingsDataSourceFactory } from '../factories/SettingsDataSourceFactory';
 import { TransactionManagerFactory } from '../factories/TransactionManagerFactory';
@@ -100,25 +100,13 @@ class DownloadFileController extends AbstractController {
       type: file.type,
     });
 
-    const stream = Readable.from(fileContents.read());
-
-    stream.on('error', err => {
-      handleError(err, { req: this.request });
-      fileContents.destroy();
-      if (!this.response.headersSent) {
-        this.response.status(500).json({ error: 'Failed to retrieve file' });
-      } else {
-        stream.destroy();
-        this.response.end();
-      }
-    });
+    const readable = await fileContents.getReadableAsync();
 
     this.response.on('close', () => {
-      fileContents.destroy();
-      stream.destroy();
+      readable.destroy();
     });
 
-    stream.pipe(this.response);
+    await pipeline(readable, this.response);
   }
 
   private async getFile(filename: string) {

--- a/app/api/core/infrastructure/express/DownloadFileController.ts
+++ b/app/api/core/infrastructure/express/DownloadFileController.ts
@@ -1,4 +1,4 @@
-import { createError } from 'api/utils';
+import { createError, handleError } from 'api/utils';
 
 import { AbstractController, Dependencies } from 'api/common.v2/infrastructure/AbstractController';
 import { FileStorage } from 'api/core/application/contracts/FileStorage';
@@ -95,17 +95,30 @@ class DownloadFileController extends AbstractController {
 
     this.addContentHeaders(file.originalname || file.filename, query, file.mimetype);
 
-    const stream = Readable.from(
-      (
-        await this.fileStorage.getFile({
-          filename: file.filename,
-          type: file.type,
-        })
-      ).read()
-    );
+    const fileContents = this.fileStorage.getFile({
+      filename: file.filename,
+      type: file.type,
+    });
+
+    const stream = Readable.from(fileContents.read());
+
+    stream.on('error', err => {
+      handleError(err, { req: this.request });
+      fileContents.destroy();
+      if (!this.response.headersSent) {
+        this.response.status(500).json({ error: 'Failed to retrieve file' });
+      } else {
+        stream.destroy();
+        this.response.end();
+      }
+    });
+
     this.response.on('close', () => {
+      console.log('CLOSED ');
+      fileContents.destroy();
       stream.destroy();
     });
+
     stream.pipe(this.response);
   }
 

--- a/app/api/core/infrastructure/express/DownloadFileController.ts
+++ b/app/api/core/infrastructure/express/DownloadFileController.ts
@@ -100,7 +100,7 @@ class DownloadFileController extends AbstractController {
       type: file.type,
     });
 
-    const readable = await fileContents.getReadableAsync();
+    const readable = await fileContents.getReadable();
 
     this.response.on('close', () => {
       readable.destroy();

--- a/app/api/core/infrastructure/express/DownloadFileController.ts
+++ b/app/api/core/infrastructure/express/DownloadFileController.ts
@@ -114,7 +114,6 @@ class DownloadFileController extends AbstractController {
     });
 
     this.response.on('close', () => {
-      console.log('CLOSED ');
       fileContents.destroy();
       stream.destroy();
     });

--- a/app/api/core/infrastructure/express/DownloadFileController.ts
+++ b/app/api/core/infrastructure/express/DownloadFileController.ts
@@ -100,13 +100,7 @@ class DownloadFileController extends AbstractController {
       type: file.type,
     });
 
-    const readable = await fileContents.getReadable();
-
-    this.response.on('close', () => {
-      readable.destroy();
-    });
-
-    await pipeline(readable, this.response);
+    await pipeline(fileContents.read(), this.response);
   }
 
   private async getFile(filename: string) {

--- a/app/api/core/infrastructure/files/DiskFile.ts
+++ b/app/api/core/infrastructure/files/DiskFile.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-restricted-import
-import { createReadStream, ReadStream } from 'fs';
+import { createReadStream } from 'fs';
 
 import path from 'path';
 import { FileContents } from '../../domain/files/FileContents';
@@ -21,21 +21,13 @@ export class DiskFile {
 
   toContent() {
     const filepath = this.path;
-    let fileStream: ReadStream | undefined;
+    const fileContents = new FileContents(async function* streamCallback() {
+      const stream = createReadStream(filepath);
+      for await (const chunk of stream) yield chunk;
+    });
 
-    const cleanup = () => {
-      if (fileStream && !fileStream.destroyed) {
-        fileStream.destroy();
-      }
-    };
+    fileContents.setGetReadable(async () => createReadStream(filepath));
 
-    return new FileContents(async function* streamCallback() {
-      try {
-        fileStream = createReadStream(filepath);
-        for await (const chunk of fileStream) yield chunk;
-      } finally {
-        cleanup();
-      }
-    }, cleanup);
+    return fileContents;
   }
 }

--- a/app/api/core/infrastructure/files/DiskFile.ts
+++ b/app/api/core/infrastructure/files/DiskFile.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-restricted-import
-import { createReadStream } from 'fs';
+import { createReadStream, ReadStream } from 'fs';
 
 import path from 'path';
 import { FileContents } from '../../domain/files/FileContents';
@@ -21,9 +21,21 @@ export class DiskFile {
 
   toContent() {
     const filepath = this.path;
+    let fileStream: ReadStream | undefined;
+
+    const cleanup = () => {
+      if (fileStream && !fileStream.destroyed) {
+        fileStream.destroy();
+      }
+    };
+
     return new FileContents(async function* streamCallback() {
-      const stream = createReadStream(filepath);
-      for await (const chunk of stream) yield chunk;
-    });
+      try {
+        fileStream = createReadStream(filepath);
+        for await (const chunk of fileStream) yield chunk;
+      } finally {
+        cleanup();
+      }
+    }, cleanup);
   }
 }

--- a/app/api/core/infrastructure/files/DiskFile.ts
+++ b/app/api/core/infrastructure/files/DiskFile.ts
@@ -21,12 +21,12 @@ export class DiskFile {
 
   toContent() {
     const filepath = this.path;
+
     const fileContents = new FileContents(async function* streamCallback() {
       const stream = createReadStream(filepath);
-      for await (const chunk of stream) yield chunk;
-    });
 
-    fileContents.setReadable(async () => createReadStream(filepath));
+      yield* stream;
+    });
 
     return fileContents;
   }

--- a/app/api/core/infrastructure/files/DiskFile.ts
+++ b/app/api/core/infrastructure/files/DiskFile.ts
@@ -26,7 +26,7 @@ export class DiskFile {
       for await (const chunk of stream) yield chunk;
     });
 
-    fileContents.setGetReadable(async () => createReadStream(filepath));
+    fileContents.setReadable(async () => createReadStream(filepath));
 
     return fileContents;
   }

--- a/app/api/core/infrastructure/files/InputFile.ts
+++ b/app/api/core/infrastructure/files/InputFile.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-restricted-import
-import { createReadStream, ReadStream } from 'fs';
+import { createReadStream } from 'fs';
 
 import { DiskFile } from 'api/core/infrastructure/files/DiskFile';
 import { mimeTypeFromUrl } from 'api/files/extensionHelper';
@@ -66,22 +66,10 @@ export class InputFile {
 
   get content() {
     const { filepath } = this;
-    let fileStream: ReadStream | undefined;
-
-    const cleanup = () => {
-      if (fileStream && !fileStream.destroyed) {
-        fileStream.destroy();
-      }
-    };
-
     return new FileContents(async function* streamCallback() {
-      try {
-        fileStream = createReadStream(filepath);
-        for await (const chunk of fileStream) yield chunk;
-      } finally {
-        cleanup();
-      }
-    }, cleanup);
+      const stream = createReadStream(filepath);
+      for await (const chunk of stream) yield chunk;
+    });
   }
 
   get metadata() {

--- a/app/api/core/infrastructure/files/InputFile.ts
+++ b/app/api/core/infrastructure/files/InputFile.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-restricted-import
-import { createReadStream } from 'fs';
+import { createReadStream, ReadStream } from 'fs';
 
 import { DiskFile } from 'api/core/infrastructure/files/DiskFile';
 import { mimeTypeFromUrl } from 'api/files/extensionHelper';
@@ -66,10 +66,22 @@ export class InputFile {
 
   get content() {
     const { filepath } = this;
+    let fileStream: ReadStream | undefined;
+
+    const cleanup = () => {
+      if (fileStream && !fileStream.destroyed) {
+        fileStream.destroy();
+      }
+    };
+
     return new FileContents(async function* streamCallback() {
-      const stream = createReadStream(filepath);
-      for await (const chunk of stream) yield chunk;
-    });
+      try {
+        fileStream = createReadStream(filepath);
+        for await (const chunk of fileStream) yield chunk;
+      } finally {
+        cleanup();
+      }
+    }, cleanup);
   }
 
   get metadata() {

--- a/app/api/core/infrastructure/files/S3FileStorage.ts
+++ b/app/api/core/infrastructure/files/S3FileStorage.ts
@@ -107,24 +107,19 @@ export class S3FileStorage implements FileStorage {
     });
 
     const client = this.s3Client;
-    let s3Stream: Readable | undefined;
 
-    const cleanup = () => {
-      if (s3Stream && !s3Stream.destroyed) {
-        s3Stream.destroy();
+    const fileContents = new FileContents(async function* streamCallback() {
+      const stream = (await catchS3Errors(async () => client.send(command))).Body as Readable;
+      for await (const chunk of stream) {
+        yield chunk;
       }
-    };
+    });
 
-    return new FileContents(async function* streamCallback() {
-      try {
-        s3Stream = (await catchS3Errors(async () => client.send(command))).Body as Readable;
-        for await (const chunk of s3Stream) {
-          yield chunk;
-        }
-      } finally {
-        cleanup();
-      }
-    }, cleanup);
+    fileContents.setGetReadable(
+      async () => (await catchS3Errors(async () => client.send(command))).Body as Readable
+    );
+
+    return fileContents;
   }
 
   async getFiles(inputs: GetFileInput[]) {

--- a/app/api/core/infrastructure/files/S3FileStorage.ts
+++ b/app/api/core/infrastructure/files/S3FileStorage.ts
@@ -110,14 +110,9 @@ export class S3FileStorage implements FileStorage {
 
     const fileContents = new FileContents(async function* streamCallback() {
       const stream = (await catchS3Errors(async () => client.send(command))).Body as Readable;
-      for await (const chunk of stream) {
-        yield chunk;
-      }
-    });
 
-    fileContents.setReadable(
-      async () => (await catchS3Errors(async () => client.send(command))).Body as Readable
-    );
+      yield* stream;
+    });
 
     return fileContents;
   }

--- a/app/api/core/infrastructure/files/S3FileStorage.ts
+++ b/app/api/core/infrastructure/files/S3FileStorage.ts
@@ -115,7 +115,7 @@ export class S3FileStorage implements FileStorage {
       }
     });
 
-    fileContents.setGetReadable(
+    fileContents.setReadable(
       async () => (await catchS3Errors(async () => client.send(command))).Body as Readable
     );
 

--- a/app/api/core/infrastructure/files/S3FileStorage.ts
+++ b/app/api/core/infrastructure/files/S3FileStorage.ts
@@ -107,12 +107,24 @@ export class S3FileStorage implements FileStorage {
     });
 
     const client = this.s3Client;
-    return new FileContents(async function* streamCallback() {
-      const stream = (await catchS3Errors(async () => client.send(command))).Body as Readable;
-      for await (const chunk of stream) {
-        yield chunk;
+    let s3Stream: Readable | undefined;
+
+    const cleanup = () => {
+      if (s3Stream && !s3Stream.destroyed) {
+        s3Stream.destroy();
       }
-    });
+    };
+
+    return new FileContents(async function* streamCallback() {
+      try {
+        s3Stream = (await catchS3Errors(async () => client.send(command))).Body as Readable;
+        for await (const chunk of s3Stream) {
+          yield chunk;
+        }
+      } finally {
+        cleanup();
+      }
+    }, cleanup);
   }
 
   async getFiles(inputs: GetFileInput[]) {

--- a/app/api/files/routes.ts
+++ b/app/api/files/routes.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import activitylogMiddleware from 'api/activitylog/activitylogMiddleware';
 import needsAuthorization from 'api/auth/authMiddleware';
 import { DownloadFileController } from 'api/core/infrastructure/express/DownloadFileController';
@@ -18,6 +19,7 @@ import { EntitySchema } from 'shared/types/entityType';
 import { fileSchema } from 'shared/types/fileSchema';
 import { FileType } from 'shared/types/fileType';
 import { UserSchema } from 'shared/types/userType';
+import { pipeline } from 'stream/promises';
 import { createError, validation } from '../utils';
 import { files } from './files';
 import { storage } from './storage';
@@ -363,10 +365,12 @@ export default (app: Application) => {
       addContentHeaders(res, req, file.originalname || file.filename, file.mimetype);
 
       const stream = await storage.readableFile(file.filename, file.type);
+
       res.on('close', () => {
         stream.destroy();
       });
-      stream.pipe(res);
+
+      await pipeline(stream, res);
     }
   );
 


### PR DESCRIPTION
[8714](https://github.com/huridocs/uwazi/issues/8714)

Stream runs in background, after express sends a response back to the client, if an error happens at this point, express do not handle the error gracefully, that's why any error while streaming the files were shutting down the process where we run the express server.

I also included code to interrupt streaming of data from storage (s3 or disk) if the client closes the connection or an error happen.


```
uncaught exception or unhandled rejection, gracefully shutting down uwazi
 S3Error: Connection timed out after 30000 ms
    at catchS3Errors (/opt/uwazi/cores/core-1.228.149/app/api/core/infrastructure/files/S3FileStorage.js:31:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async FileContents.streamCallback (/opt/uwazi/cores/core-1.228.149/app/api/core/infrastructure/files/S3FileStorage.js:111:23)
    at async FileContents.read (/opt/uwazi/cores/core-1.228.149/app/api/core/domain/files/FileContents.js:12:24)
    at async next (node:internal/streams/from:85:11) {
  [cause]: Error [TimeoutError]: Connection timed out after 30000 ms
      at TLSSocket.onTimeout (/opt/uwazi/cores/core-1.228.149/node_modules/@smithy/node-http-handler/dist-cjs/index.js:131:28)
      at Object.onceWrapper (node:events:628:28)
      at TLSSocket.emit (node:events:526:35)
      at TLSSocket.emit (node:domain:488:12)
      at Socket._onTimeout (node:net:589:8)
      at listOnTimeout (node:internal/timers:573:17)
      at process.processTimers (node:internal/timers:514:7) {
    '$metadata': { attempts: 5, totalRetryDelay: 1018 }
  }
}
original error: {}
```