### PR TITLE
Allaggregations false by default on search

### DIFF
--- a/app/react/Library/reducers/reducer.js
+++ b/app/react/Library/reducers/reducer.js
@@ -22,7 +22,6 @@ if (isClient) {
 const defaultSearch = prioritySortingCriteria.get({ templates });
 defaultSearch.searchTerm = '';
 defaultSearch.filters = {};
-defaultSearch.allAggregations = true;
 defaultSearch.includeUnpublished = true;
 defaultSearch.publishedStatus = { values: ['published', 'restricted'] };
 


### PR DESCRIPTION
The flag is meant to be used in extraordinary scenarios when one needs
all the aggregations no matter if the template share properties or not.
