### PR TITLE
Tweak v2 entity validations

### DIFF
--- a/app/api/core/application/propertyAssignmentCreatorService/AbstractPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/AbstractPropertyAssignmentCreatorService.ts
@@ -1,0 +1,8 @@
+type Context = {
+  validateRequired: boolean;
+};
+
+const defaultContext: Context = { validateRequired: false };
+
+export type { Context as PropertyAssignmentCreatorServiceContext };
+export { defaultContext as defaultPropertyAssignmentCreatorServiceContext };

--- a/app/api/core/application/propertyAssignmentCreatorService/AbstractPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/AbstractPropertyAssignmentCreatorService.ts
@@ -1,8 +1,29 @@
+import { PropertyAssignment } from 'api/core/domain/template/PropertyValue';
+import {
+  CreatePropertyAssignmentInput,
+  PropertyAssignmentCreatorService,
+} from './PropertyAssignmentCreatorService';
+
 type Context = {
   validateRequired: boolean;
 };
 
 const defaultContext: Context = { validateRequired: false };
 
+abstract class AbstractPropertyAssignmentCreatorService
+  implements PropertyAssignmentCreatorService
+{
+  protected context: Context;
+
+  constructor(context: Context = defaultContext) {
+    this.context = context;
+  }
+
+  abstract create(
+    input: CreatePropertyAssignmentInput
+  ): Promise<PropertyAssignment | PropertyAssignment[]>;
+}
+
 export type { Context as PropertyAssignmentCreatorServiceContext };
 export { defaultContext as defaultPropertyAssignmentCreatorServiceContext };
+export { AbstractPropertyAssignmentCreatorService };

--- a/app/api/core/application/propertyAssignmentCreatorService/DefaultPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/DefaultPropertyAssignmentCreatorService.ts
@@ -3,8 +3,20 @@ import {
   CreatePropertyAssignmentInput,
   PropertyAssignmentCreatorService,
 } from './PropertyAssignmentCreatorService';
+import {
+  defaultPropertyAssignmentCreatorServiceContext,
+  PropertyAssignmentCreatorServiceContext,
+} from './AbstractPropertyAssignmentCreatorService';
 
 export class DefaultPropertyAssignmentCreatorService implements PropertyAssignmentCreatorService {
+  private context: PropertyAssignmentCreatorServiceContext;
+
+  constructor(
+    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
+  ) {
+    this.context = context;
+  }
+
   // eslint-disable-next-line class-methods-use-this
   async create({ propertyAssignment, template }: CreatePropertyAssignmentInput) {
     const { name, value, language } = propertyAssignment;
@@ -12,7 +24,7 @@ export class DefaultPropertyAssignmentCreatorService implements PropertyAssignme
     return template.createPropertyAssignment(
       name,
       { value: value as PropertyValue[], language },
-      true
+      this.context.validateRequired
     );
   }
 }

--- a/app/api/core/application/propertyAssignmentCreatorService/DefaultPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/DefaultPropertyAssignmentCreatorService.ts
@@ -1,22 +1,8 @@
 import { PropertyValue } from 'api/core/domain/template/PropertyValue';
-import {
-  CreatePropertyAssignmentInput,
-  PropertyAssignmentCreatorService,
-} from './PropertyAssignmentCreatorService';
-import {
-  defaultPropertyAssignmentCreatorServiceContext,
-  PropertyAssignmentCreatorServiceContext,
-} from './AbstractPropertyAssignmentCreatorService';
+import { CreatePropertyAssignmentInput } from './PropertyAssignmentCreatorService';
+import { AbstractPropertyAssignmentCreatorService } from './AbstractPropertyAssignmentCreatorService';
 
-export class DefaultPropertyAssignmentCreatorService implements PropertyAssignmentCreatorService {
-  private context: PropertyAssignmentCreatorServiceContext;
-
-  constructor(
-    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
-  ) {
-    this.context = context;
-  }
-
+export class DefaultPropertyAssignmentCreatorService extends AbstractPropertyAssignmentCreatorService {
   // eslint-disable-next-line class-methods-use-this
   async create({ propertyAssignment, template }: CreatePropertyAssignmentInput) {
     const { name, value, language } = propertyAssignment;

--- a/app/api/core/application/propertyAssignmentCreatorService/DefaultPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/DefaultPropertyAssignmentCreatorService.ts
@@ -3,7 +3,6 @@ import { CreatePropertyAssignmentInput } from './PropertyAssignmentCreatorServic
 import { AbstractPropertyAssignmentCreatorService } from './AbstractPropertyAssignmentCreatorService';
 
 export class DefaultPropertyAssignmentCreatorService extends AbstractPropertyAssignmentCreatorService {
-  // eslint-disable-next-line class-methods-use-this
   async create({ propertyAssignment, template }: CreatePropertyAssignmentInput) {
     const { name, value, language } = propertyAssignment;
 

--- a/app/api/core/application/propertyAssignmentCreatorService/ImagePropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/ImagePropertyAssignmentCreatorService.ts
@@ -5,10 +5,22 @@ import {
   CreatePropertyAssignmentInput,
   PropertyAssignmentCreatorService,
 } from './PropertyAssignmentCreatorService';
+import {
+  defaultPropertyAssignmentCreatorServiceContext,
+  PropertyAssignmentCreatorServiceContext,
+} from './AbstractPropertyAssignmentCreatorService';
 
 type ImageValueInput = { value: string } | { attachment: number };
 
 export class ImagePropertyAssignmentCreatorService implements PropertyAssignmentCreatorService {
+  private context: PropertyAssignmentCreatorServiceContext;
+
+  constructor(
+    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
+  ) {
+    this.context = context;
+  }
+
   // eslint-disable-next-line max-statements
   async create({
     propertyAssignment,
@@ -38,7 +50,9 @@ export class ImagePropertyAssignmentCreatorService implements PropertyAssignment
       };
     });
 
-    createdAssignments.push(property.createPropertyAssignment({ value: mapped }, true));
+    createdAssignments.push(
+      property.createPropertyAssignment({ value: mapped }, this.context.validateRequired)
+    );
 
     return createdAssignments;
   }

--- a/app/api/core/application/propertyAssignmentCreatorService/ImagePropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/ImagePropertyAssignmentCreatorService.ts
@@ -1,26 +1,12 @@
 import { PropertyAssignment } from 'api/core/domain/template/PropertyValue';
 import { ImageProperty } from 'api/core/domain/template/ImageProperty';
 import { AttachmentNotFoundError } from 'api/core/domain/entity/errors';
-import {
-  CreatePropertyAssignmentInput,
-  PropertyAssignmentCreatorService,
-} from './PropertyAssignmentCreatorService';
-import {
-  defaultPropertyAssignmentCreatorServiceContext,
-  PropertyAssignmentCreatorServiceContext,
-} from './AbstractPropertyAssignmentCreatorService';
+import { CreatePropertyAssignmentInput } from './PropertyAssignmentCreatorService';
+import { AbstractPropertyAssignmentCreatorService } from './AbstractPropertyAssignmentCreatorService';
 
 type ImageValueInput = { value: string } | { attachment: number };
 
-export class ImagePropertyAssignmentCreatorService implements PropertyAssignmentCreatorService {
-  private context: PropertyAssignmentCreatorServiceContext;
-
-  constructor(
-    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
-  ) {
-    this.context = context;
-  }
-
+export class ImagePropertyAssignmentCreatorService extends AbstractPropertyAssignmentCreatorService {
   // eslint-disable-next-line max-statements
   async create({
     propertyAssignment,

--- a/app/api/core/application/propertyAssignmentCreatorService/MediaPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/MediaPropertyAssignmentCreatorService.ts
@@ -1,26 +1,12 @@
 import { PropertyAssignment } from 'api/core/domain/template/PropertyValue';
 import { MediaProperty } from 'api/core/domain/template/MediaProperty';
 import { AttachmentNotFoundError } from 'api/core/domain/entity/errors';
-import {
-  CreatePropertyAssignmentInput,
-  PropertyAssignmentCreatorService,
-} from './PropertyAssignmentCreatorService';
-import {
-  defaultPropertyAssignmentCreatorServiceContext,
-  PropertyAssignmentCreatorServiceContext,
-} from './AbstractPropertyAssignmentCreatorService';
+import { CreatePropertyAssignmentInput } from './PropertyAssignmentCreatorService';
+import { AbstractPropertyAssignmentCreatorService } from './AbstractPropertyAssignmentCreatorService';
 
 type MediaValueInput = { value: string } | { attachment: number; timeLinks?: string };
 
-export class MediaPropertyAssignmentCreatorService implements PropertyAssignmentCreatorService {
-  private context: PropertyAssignmentCreatorServiceContext;
-
-  constructor(
-    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
-  ) {
-    this.context = context;
-  }
-
+export class MediaPropertyAssignmentCreatorService extends AbstractPropertyAssignmentCreatorService {
   // eslint-disable-next-line max-statements
   async create({
     propertyAssignment,

--- a/app/api/core/application/propertyAssignmentCreatorService/MediaPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/MediaPropertyAssignmentCreatorService.ts
@@ -5,10 +5,22 @@ import {
   CreatePropertyAssignmentInput,
   PropertyAssignmentCreatorService,
 } from './PropertyAssignmentCreatorService';
+import {
+  defaultPropertyAssignmentCreatorServiceContext,
+  PropertyAssignmentCreatorServiceContext,
+} from './AbstractPropertyAssignmentCreatorService';
 
 type MediaValueInput = { value: string } | { attachment: number; timeLinks?: string };
 
 export class MediaPropertyAssignmentCreatorService implements PropertyAssignmentCreatorService {
+  private context: PropertyAssignmentCreatorServiceContext;
+
+  constructor(
+    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
+  ) {
+    this.context = context;
+  }
+
   // eslint-disable-next-line max-statements
   async create({
     propertyAssignment,
@@ -38,7 +50,9 @@ export class MediaPropertyAssignmentCreatorService implements PropertyAssignment
       };
     });
 
-    createdAssignments.push(property.createPropertyAssignment({ value: mapped }, true));
+    createdAssignments.push(
+      property.createPropertyAssignment({ value: mapped }, this.context.validateRequired)
+    );
 
     return createdAssignments;
   }

--- a/app/api/core/application/propertyAssignmentCreatorService/PropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/PropertyAssignmentCreatorService.ts
@@ -8,7 +8,7 @@ type PropertyValueInput =
   | { attachment: number }
   | { value: string }
   | { value: number }
-  | { value: { from: number; to: number } }
+  | { value: { from: number | null; to: number | null } }
   | { value: { lat: number; lon: number; label?: string } }
   | { value: { url: string; label?: string } }
   | { value: { [childName: string]: { value: unknown; label?: string }[] } };

--- a/app/api/core/application/propertyAssignmentCreatorService/PropertyAssignmentCreatorServiceStrategy.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/PropertyAssignmentCreatorServiceStrategy.ts
@@ -85,6 +85,24 @@ class PropertyAssignmentCreatorServiceStrategy {
       default: new DefaultPropertyAssignmentCreatorService(),
     });
   }
+
+  static createWithRequired({ settingsDS, thesauriDS, translationsDS, entitiesDS }: CreateProps) {
+    const context = { validateRequired: true };
+
+    return new PropertyAssignmentCreatorServiceStrategy({
+      select: new SelectPropertyAssignmentCreatorService(
+        { settingsDS, thesauriDS, translationsDS },
+        context
+      ),
+      relationship: new RelationshipPropertyAssignmentCreatorService(
+        { settingsDS, entitiesDS },
+        context
+      ),
+      image: new ImagePropertyAssignmentCreatorService(context),
+      media: new MediaPropertyAssignmentCreatorService(context),
+      default: new DefaultPropertyAssignmentCreatorService(context),
+    });
+  }
 }
 
 export { PropertyAssignmentCreatorServiceStrategy };

--- a/app/api/core/application/propertyAssignmentCreatorService/RelationshipPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/RelationshipPropertyAssignmentCreatorService.ts
@@ -7,12 +7,9 @@ import {
   RelationshipTemplateMismatchError,
 } from 'api/core/domain/entity/errors';
 import { SettingsDataSource } from '../contracts/SettingsDataSource';
+import { CreatePropertyAssignmentInput } from './PropertyAssignmentCreatorService';
 import {
-  CreatePropertyAssignmentInput,
-  PropertyAssignmentCreatorService,
-} from './PropertyAssignmentCreatorService';
-import {
-  defaultPropertyAssignmentCreatorServiceContext,
+  AbstractPropertyAssignmentCreatorService,
   PropertyAssignmentCreatorServiceContext,
 } from './AbstractPropertyAssignmentCreatorService';
 
@@ -21,16 +18,12 @@ type Deps = {
   entitiesDS: MultiLanguageEntityDataSource;
 };
 
-export class RelationshipPropertyAssignmentCreatorService
-  implements PropertyAssignmentCreatorService
-{
-  private context: PropertyAssignmentCreatorServiceContext;
-
+export class RelationshipPropertyAssignmentCreatorService extends AbstractPropertyAssignmentCreatorService {
   constructor(
     private deps: Deps,
-    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
+    context?: PropertyAssignmentCreatorServiceContext
   ) {
-    this.context = context;
+    super(context);
   }
 
   // eslint-disable-next-line max-statements

--- a/app/api/core/application/propertyAssignmentCreatorService/RelationshipPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/RelationshipPropertyAssignmentCreatorService.ts
@@ -10,6 +10,7 @@ import { SettingsDataSource } from '../contracts/SettingsDataSource';
 import { CreatePropertyAssignmentInput } from './PropertyAssignmentCreatorService';
 import {
   AbstractPropertyAssignmentCreatorService,
+  defaultPropertyAssignmentCreatorServiceContext,
   PropertyAssignmentCreatorServiceContext,
 } from './AbstractPropertyAssignmentCreatorService';
 
@@ -21,7 +22,7 @@ type Deps = {
 export class RelationshipPropertyAssignmentCreatorService extends AbstractPropertyAssignmentCreatorService {
   constructor(
     private deps: Deps,
-    context?: PropertyAssignmentCreatorServiceContext
+    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
   ) {
     super(context);
   }

--- a/app/api/core/application/propertyAssignmentCreatorService/RelationshipPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/RelationshipPropertyAssignmentCreatorService.ts
@@ -11,6 +11,10 @@ import {
   CreatePropertyAssignmentInput,
   PropertyAssignmentCreatorService,
 } from './PropertyAssignmentCreatorService';
+import {
+  defaultPropertyAssignmentCreatorServiceContext,
+  PropertyAssignmentCreatorServiceContext,
+} from './AbstractPropertyAssignmentCreatorService';
 
 type Deps = {
   settingsDS: SettingsDataSource;
@@ -20,7 +24,14 @@ type Deps = {
 export class RelationshipPropertyAssignmentCreatorService
   implements PropertyAssignmentCreatorService
 {
-  constructor(private deps: Deps) {}
+  private context: PropertyAssignmentCreatorServiceContext;
+
+  constructor(
+    private deps: Deps,
+    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
+  ) {
+    this.context = context;
+  }
 
   // eslint-disable-next-line max-statements
   async create({
@@ -85,7 +96,13 @@ export class RelationshipPropertyAssignmentCreatorService
         return base;
       });
 
-      assignments.push(template.createPropertyAssignment(property.name, { value, language }, true));
+      assignments.push(
+        template.createPropertyAssignment(
+          property.name,
+          { value, language },
+          this.context.validateRequired
+        )
+      );
     });
 
     return assignments;

--- a/app/api/core/application/propertyAssignmentCreatorService/SelectPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/SelectPropertyAssignmentCreatorService.ts
@@ -9,6 +9,10 @@ import {
   PropertyAssignmentCreatorService,
 } from './PropertyAssignmentCreatorService';
 import { ThesauriDataSource } from '../contracts/ThesauriDataSource';
+import {
+  defaultPropertyAssignmentCreatorServiceContext,
+  PropertyAssignmentCreatorServiceContext,
+} from './AbstractPropertyAssignmentCreatorService';
 
 type Deps = {
   settingsDS: SettingsDataSource;
@@ -17,7 +21,14 @@ type Deps = {
 };
 
 export class SelectPropertyAssignmentCreatorService implements PropertyAssignmentCreatorService {
-  constructor(private deps: Deps) {}
+  private context: PropertyAssignmentCreatorServiceContext;
+
+  constructor(
+    private deps: Deps,
+    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
+  ) {
+    this.context = context;
+  }
 
   // eslint-disable-next-line max-statements
   async create({
@@ -66,7 +77,11 @@ export class SelectPropertyAssignmentCreatorService implements PropertyAssignmen
       });
 
       propertyAssignments.push(
-        template.createPropertyAssignment(property.name, { value, language }, true)
+        template.createPropertyAssignment(
+          property.name,
+          { value, language },
+          this.context.validateRequired
+        )
       );
     });
 

--- a/app/api/core/application/propertyAssignmentCreatorService/SelectPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/SelectPropertyAssignmentCreatorService.ts
@@ -8,6 +8,7 @@ import { CreatePropertyAssignmentInput } from './PropertyAssignmentCreatorServic
 import { ThesauriDataSource } from '../contracts/ThesauriDataSource';
 import {
   AbstractPropertyAssignmentCreatorService,
+  defaultPropertyAssignmentCreatorServiceContext,
   PropertyAssignmentCreatorServiceContext,
 } from './AbstractPropertyAssignmentCreatorService';
 
@@ -20,7 +21,7 @@ type Deps = {
 export class SelectPropertyAssignmentCreatorService extends AbstractPropertyAssignmentCreatorService {
   constructor(
     private deps: Deps,
-    context?: PropertyAssignmentCreatorServiceContext
+    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
   ) {
     super(context);
   }

--- a/app/api/core/application/propertyAssignmentCreatorService/SelectPropertyAssignmentCreatorService.ts
+++ b/app/api/core/application/propertyAssignmentCreatorService/SelectPropertyAssignmentCreatorService.ts
@@ -4,13 +4,10 @@ import { TranslationsDataSource } from 'api/i18n.v2/contracts/TranslationsDataSo
 import { ThesaurusValue } from 'api/core/domain/thesaurus/Thesaurus';
 import { TranslationCollection } from 'api/i18n.v2/model/TranslationCollection';
 import { SettingsDataSource } from '../contracts/SettingsDataSource';
-import {
-  CreatePropertyAssignmentInput,
-  PropertyAssignmentCreatorService,
-} from './PropertyAssignmentCreatorService';
+import { CreatePropertyAssignmentInput } from './PropertyAssignmentCreatorService';
 import { ThesauriDataSource } from '../contracts/ThesauriDataSource';
 import {
-  defaultPropertyAssignmentCreatorServiceContext,
+  AbstractPropertyAssignmentCreatorService,
   PropertyAssignmentCreatorServiceContext,
 } from './AbstractPropertyAssignmentCreatorService';
 
@@ -20,14 +17,12 @@ type Deps = {
   thesauriDS: ThesauriDataSource;
 };
 
-export class SelectPropertyAssignmentCreatorService implements PropertyAssignmentCreatorService {
-  private context: PropertyAssignmentCreatorServiceContext;
-
+export class SelectPropertyAssignmentCreatorService extends AbstractPropertyAssignmentCreatorService {
   constructor(
     private deps: Deps,
-    context: PropertyAssignmentCreatorServiceContext = defaultPropertyAssignmentCreatorServiceContext
+    context?: PropertyAssignmentCreatorServiceContext
   ) {
-    this.context = context;
+    super(context);
   }
 
   // eslint-disable-next-line max-statements

--- a/app/api/core/application/specs/CreateEntity.spec.ts
+++ b/app/api/core/application/specs/CreateEntity.spec.ts
@@ -166,6 +166,10 @@ const fixtures: DBFixture = {
       factory.property('attached_media_1', 'media'),
       factory.property('attached_media_2', 'media'),
     ]),
+
+    factory.template('Document With Required', [
+      factory.property('required_text', 'text', { required: true }),
+    ]),
   ],
 
   entities: [
@@ -234,12 +238,13 @@ const createSut = (props: CreateSutProps = {}) => {
     dispatcher: jobsDispatcher,
   });
 
-  const propertyAssignmentCreatorServiceStrategy = PropertyAssignmentCreatorServiceStrategy.create({
-    entitiesDS,
-    settingsDS,
-    thesauriDS,
-    translationsDS,
-  });
+  const propertyAssignmentCreatorServiceStrategy =
+    PropertyAssignmentCreatorServiceStrategy.createWithRequired({
+      entitiesDS,
+      settingsDS,
+      thesauriDS,
+      translationsDS,
+    });
 
   jest.spyOn(fileService, 'storeFiles').mockResolvedValue();
   jest.spyOn(fileService, 'insert').mockResolvedValue();
@@ -613,5 +618,19 @@ describe('CreateEntityUseCase', () => {
 
     const targetLanguage = emittedArg.getData().targetLanguageKey;
     expect(targetLanguage).toBe('es');
+  });
+
+  it('should throw when a required property has no value', async () => {
+    const { sut } = createSut();
+
+    await expect(
+      sut.execute({
+        templateId: factory.id('Document With Required').toHexString(),
+        propertyAssignments: [
+          { name: 'title', value: [{ value: 'My entity title' }] },
+          { name: 'required_text', value: [] },
+        ],
+      })
+    ).rejects.toThrow('Text Property is required');
   });
 });

--- a/app/api/core/application/specs/DefaultPropertyAssignmentCreatorService.spec.ts
+++ b/app/api/core/application/specs/DefaultPropertyAssignmentCreatorService.spec.ts
@@ -1,0 +1,95 @@
+import { getFixturesFactory } from 'api/utils/fixturesFactory';
+import { DBFixture } from 'api/utils/testing_db';
+import { testingEnvironment } from 'api/utils/testingEnvironment';
+import { MongoTemplateMapper } from 'api/core/infrastructure/mongodb/template/MongoTemplateMapper';
+import { DefaultPropertyAssignmentCreatorService } from '../propertyAssignmentCreatorService/DefaultPropertyAssignmentCreatorService';
+
+const factory = getFixturesFactory();
+
+const fixtures: DBFixture = {
+  settings: [
+    {
+      languages: [
+        { default: true, key: 'en', label: 'English' },
+        { key: 'pt', label: 'Portuguese' },
+      ],
+    },
+  ],
+
+  templates: [
+    factory.template('Document', [
+      factory.property('text', 'text'),
+      factory.property('required_text', 'text', { required: true }),
+    ]),
+  ],
+};
+
+describe('DefaultPropertyAssignmentCreatorService', () => {
+  beforeAll(async () => {
+    await testingEnvironment.setUp({});
+  });
+
+  beforeEach(async () => testingEnvironment.setFixtures(fixtures));
+
+  afterAll(async () => {
+    await testingEnvironment.tearDown();
+  });
+
+  it('should create a property assignment for a basic text property', async () => {
+    const sut = new DefaultPropertyAssignmentCreatorService();
+    const templateDBO = await testingEnvironment.db
+      .getCollection('templates')!
+      .findOne({ _id: factory.id('Document') });
+
+    const template = MongoTemplateMapper.toDomain(templateDBO as any);
+
+    const result = await sut.create({
+      template,
+      propertyAssignment: { name: 'text', value: [{ value: 'Hello world' }] },
+    });
+
+    expect(result).toEqual({
+      isTranslatable: true,
+      name: 'text',
+      type: 'text',
+      value: [{ value: 'Hello world' }],
+    });
+  });
+
+  it('should throw when validateRequired is true and a required text property has no value', async () => {
+    const sut = new DefaultPropertyAssignmentCreatorService({ validateRequired: true });
+    const templateDBO = await testingEnvironment.db
+      .getCollection('templates')!
+      .findOne({ _id: factory.id('Document') });
+
+    const template = MongoTemplateMapper.toDomain(templateDBO as any);
+
+    await expect(
+      sut.create({
+        template,
+        propertyAssignment: { name: 'required_text', value: [] },
+      })
+    ).rejects.toThrow('Text Property is required');
+  });
+
+  it('should not throw when validateRequired is false (default) and a required text property has no value', async () => {
+    const sut = new DefaultPropertyAssignmentCreatorService();
+    const templateDBO = await testingEnvironment.db
+      .getCollection('templates')!
+      .findOne({ _id: factory.id('Document') });
+
+    const template = MongoTemplateMapper.toDomain(templateDBO as any);
+
+    await expect(
+      sut.create({
+        template,
+        propertyAssignment: { name: 'required_text', value: [] },
+      })
+    ).resolves.toEqual({
+      isTranslatable: true,
+      name: 'required_text',
+      type: 'text',
+      value: [],
+    });
+  });
+});

--- a/app/api/core/application/specs/ImagePropertyAssignmentCreatorService.spec.ts
+++ b/app/api/core/application/specs/ImagePropertyAssignmentCreatorService.spec.ts
@@ -140,4 +140,20 @@ describe('ImagePropertyAssignmentCreatorService', () => {
       })
     ).rejects.toThrow(PropertyNotFoundError);
   });
+
+  it('should throw when validateRequired is true and a required property has no value', async () => {
+    const sut = new ImagePropertyAssignmentCreatorService({ validateRequired: true });
+    const templateDBO = await testingEnvironment.db
+      .getCollection('templates')!
+      .findOne({ _id: factory.id('Document') });
+
+    const template = MongoTemplateMapper.toDomain(templateDBO as any);
+
+    await expect(
+      sut.create({
+        template,
+        propertyAssignment: { name: 'required_image', value: [] },
+      })
+    ).rejects.toThrow('Image Property is required');
+  });
 });

--- a/app/api/core/application/specs/MediaPropertyAssignmentCreatorService.spec.ts
+++ b/app/api/core/application/specs/MediaPropertyAssignmentCreatorService.spec.ts
@@ -333,7 +333,7 @@ describe('MediaPropertyAssignmentCreatorService', () => {
     });
 
     it('should throw when required property has no value', async () => {
-      const { sut } = createSut();
+      const sut = new MediaPropertyAssignmentCreatorService({ validateRequired: true });
       const templateDBO = await testingEnvironment.db
         .getCollection('templates')!
         .findOne({ _id: factory.id('Document') });

--- a/app/api/core/application/specs/MediaPropertyAssignmentCreatorService.spec.ts
+++ b/app/api/core/application/specs/MediaPropertyAssignmentCreatorService.spec.ts
@@ -400,5 +400,31 @@ describe('MediaPropertyAssignmentCreatorService', () => {
         },
       ]);
     });
+
+    it('should not throw when validateRequired is false (default) and a required media property has no value', async () => {
+      const { sut } = createSut();
+      const templateDBO = await testingEnvironment.db
+        .getCollection('templates')!
+        .findOne({ _id: factory.id('Document') });
+
+      const template = MongoTemplateMapper.toDomain(templateDBO as any);
+
+      await expect(
+        sut.create({
+          template,
+          propertyAssignment: {
+            name: 'required_media',
+            value: [],
+          },
+        })
+      ).resolves.toEqual([
+        {
+          isTranslatable: true,
+          name: 'required_media',
+          type: 'media',
+          value: [],
+        },
+      ]);
+    });
   });
 });

--- a/app/api/core/application/specs/RelationshipPropertyAssignmentCreatorService.spec.ts
+++ b/app/api/core/application/specs/RelationshipPropertyAssignmentCreatorService.spec.ts
@@ -240,6 +240,7 @@ const fixtures: DBFixture = {
         },
       }),
       factory.relationshipProp('rel_prop_no_inherit', 'Document B'),
+      factory.relationshipProp('required_rel', 'Document B', { required: true }),
     ]),
 
     factory.template('Document B', [
@@ -1431,5 +1432,29 @@ describe('RelationshipPropertyAssignmentCreatorService', () => {
         propertyAssignment: { name: 'text_rel', value: [{ value: 'C1' }] },
       })
     ).rejects.toThrow('expects template');
+  });
+
+  it('should throw when validateRequired is true and a required relationship property has no value', async () => {
+    const transactionManager = TransactionManagerFactory.default();
+    const entitiesDS = new MongoMultiLanguageEntityDataSource(getConnection(), transactionManager);
+    const settingsDS = SettingsDataSourceFactory.default(transactionManager);
+
+    const sut = new RelationshipPropertyAssignmentCreatorService(
+      { entitiesDS, settingsDS },
+      { validateRequired: true }
+    );
+
+    const templateDBO = await testingEnvironment.db
+      .getCollection('templates')!
+      .findOne({ _id: factory.id('Document A') });
+
+    const template = MongoTemplateMapper.toDomain(templateDBO as any);
+
+    await expect(
+      sut.create({
+        template,
+        propertyAssignment: { name: 'required_rel', value: [] },
+      })
+    ).rejects.toThrow('Relationship Property is required');
   });
 });

--- a/app/api/core/application/specs/SelectPropertyAssignmentCreatorService.spec.ts
+++ b/app/api/core/application/specs/SelectPropertyAssignmentCreatorService.spec.ts
@@ -264,6 +264,11 @@ const fixtures: DBFixture = {
       factory.property('select_grouped', 'select', {
         content: factory.id('GroupedFruits').toHexString(),
       }),
+
+      factory.property('required_select', 'select', {
+        content: factory.id('Fruits').toHexString(),
+        required: true,
+      }),
     ]),
   ],
 };
@@ -594,5 +599,30 @@ describe('SelectPropertyAssignmentCreatorService', () => {
 
     expect(assignmentsGrouped[0].value).toHaveLength(1);
     expect(assignmentsGrouped[0].value[0].value).toBe('cherry_id');
+  });
+
+  it('should throw when validateRequired is true and a required select property has no value', async () => {
+    const transactionManager = TransactionManagerFactory.default();
+    const translationsDS = DefaultTranslationsDataSource(transactionManager);
+    const thesauriDS = ThesauriDataSourceFactory.default(transactionManager);
+    const settingsDS = SettingsDataSourceFactory.default(transactionManager);
+
+    const sut = new SelectPropertyAssignmentCreatorService(
+      { thesauriDS, translationsDS, settingsDS },
+      { validateRequired: true }
+    );
+
+    const templateDBO = await testingEnvironment.db
+      .getCollection('templates')!
+      .findOne({ _id: factory.id('Document') });
+
+    const template = MongoTemplateMapper.toDomain(templateDBO as any);
+
+    await expect(
+      sut.create({
+        template,
+        propertyAssignment: { name: 'required_select', value: [] },
+      })
+    ).rejects.toThrow('Select/MultiSelect Property is required');
   });
 });

--- a/app/api/core/application/specs/UpdateEntity.spec.ts
+++ b/app/api/core/application/specs/UpdateEntity.spec.ts
@@ -34,12 +34,13 @@ const createSut = (_deps?: Partial<UpdateEntityUseCaseDeps>) => {
   const translationsDS = DefaultTranslationsDataSource(transactionManager);
   const idGenerator = IdGeneratorFactory.default();
 
-  const propertyAssignmentCreatorServiceStrategy = PropertyAssignmentCreatorServiceStrategy.create({
-    entitiesDS,
-    settingsDS,
-    thesauriDS,
-    translationsDS,
-  });
+  const propertyAssignmentCreatorServiceStrategy =
+    PropertyAssignmentCreatorServiceStrategy.createWithRequired({
+      entitiesDS,
+      settingsDS,
+      thesauriDS,
+      translationsDS,
+    });
 
   const fileStorage = TestUtils.mockClass<FileSystemStorage>({ storeFile: jest.fn() });
   const eventBus = TestUtils.mockClass<EventsBus>({ emit: jest.fn() });
@@ -517,6 +518,17 @@ describe('UpdateEntityUseCase', () => {
           media: [{ value: 'https://example.com/video.mp4' }],
         },
       ]);
+    });
+    it('should throw when a required property has no value', async () => {
+      const { sut } = createSut();
+
+      await expect(
+        sut.execute({
+          sharedId: 'required_entity',
+          language: 'en',
+          propertyAssignments: [{ name: 'required_text', value: [{ value: '' }] }],
+        })
+      ).rejects.toThrow('Text Property is required');
     });
   });
 

--- a/app/api/core/application/specs/UpdateEntityFixtures.ts
+++ b/app/api/core/application/specs/UpdateEntityFixtures.ts
@@ -107,6 +107,10 @@ const fixtures: DBFixture = {
 
     factory.template('Related Template', [factory.property('related_text', 'text')]),
 
+    factory.template('Template With Required', [
+      factory.property('required_text', 'text', { required: true }),
+    ]),
+
     factory.template('Full Template', [
       factory.property('text', 'text'),
       factory.property('numeric', 'numeric'),
@@ -140,6 +144,28 @@ const fixtures: DBFixture = {
   ],
 
   entities: [
+    ...factory.entityInMultipleLanguages(
+      ['en', 'pt'],
+      'required_entity',
+      'Template With Required',
+      {},
+      { title: 'Required Entity' },
+      {
+        en: {
+          title: 'Required Entity EN',
+          metadata: {
+            required_text: [factory.metadataValue('Some required text')],
+          },
+        },
+        pt: {
+          title: 'Required Entity PT',
+          metadata: {
+            required_text: [factory.metadataValue('Some required text')],
+          },
+        },
+      }
+    ),
+
     ...factory.entityInMultipleLanguages(
       ['en', 'pt'],
       'entity1',

--- a/app/api/core/domain/template/DateRangeProperty.ts
+++ b/app/api/core/domain/template/DateRangeProperty.ts
@@ -11,11 +11,19 @@ type Props = {
 
 const RangeSchema = z
   .object({
-    from: z.number({ required_error: 'Date Range Property "from" value must be provided.' }),
-    to: z.number({ required_error: 'Date Range Property "to" value must be provided.' }),
+    from: z
+      .number({ required_error: 'Date Range Property "from" value must be provided.' })
+      .nullable(),
+    to: z.number({ required_error: 'Date Range Property "to" value must be provided.' }).nullable(),
   })
   .superRefine((range, ctx) => {
-    if (range.to < range.from) {
+    if (range.from === null && range.to === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Date Range Property requires at least one of "from" or "to".',
+      });
+    }
+    if (range.from !== null && range.to !== null && range.to < range.from) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Date Range Property "to" cannot be before "from".',
@@ -57,7 +65,7 @@ class DateRangeProperty extends FilterableProperty {
     shouldValidateForRequired = false
   ): PropertyAssignment<DateRangeEntry> {
     const parsedValue = createSchema(shouldValidateForRequired ? this.required : false).parse(
-      value.filter(v => v?.value?.from?.toString()?.length && v?.value?.to?.toString()?.length)
+      value.filter(v => v?.value?.from != null || v?.value?.to != null)
     );
 
     return {

--- a/app/api/core/domain/template/MultiDateRangeProperty.ts
+++ b/app/api/core/domain/template/MultiDateRangeProperty.ts
@@ -11,11 +11,21 @@ type Props = {
 
 const RangeSchema = z
   .object({
-    from: z.number({ required_error: 'Multi Date Range Property "from" value must be provided.' }),
-    to: z.number({ required_error: 'Multi Date Range Property "to" value must be provided.' }),
+    from: z
+      .number({ required_error: 'Multi Date Range Property "from" value must be provided.' })
+      .nullable(),
+    to: z
+      .number({ required_error: 'Multi Date Range Property "to" value must be provided.' })
+      .nullable(),
   })
   .superRefine((range, ctx) => {
-    if (range.to < range.from) {
+    if (range.from === null && range.to === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Multi Date Range Property requires at least one of "from" or "to".',
+      });
+    }
+    if (range.from !== null && range.to !== null && range.to < range.from) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Multi Date Range Property "to" cannot be before "from".',
@@ -54,7 +64,7 @@ class MultiDateRangeProperty extends FilterableProperty {
     shouldValidateForRequired = false
   ): PropertyAssignment<DateRangeEntry> {
     const parsed = createSchema(shouldValidateForRequired ? this.required : false).parse(
-      value.filter(v => v?.value?.from?.toString()?.length && v?.value?.to?.toString()?.length)
+      value.filter(v => v?.value?.from != null || v?.value?.to != null)
     );
 
     return {

--- a/app/api/core/domain/template/PropertyValue.ts
+++ b/app/api/core/domain/template/PropertyValue.ts
@@ -16,7 +16,7 @@ export type TextPropertyValue = { value: string };
 export type NumericPropertyValue = { value: number };
 export type MarkdownEntry = { value: string };
 export type DateEntry = { value: number };
-export type DateRangeEntry = { value: { from: number; to: number } };
+export type DateRangeEntry = { value: { from: number | null; to: number | null } };
 export type GeolocationEntry = { value: { lat: number; lon: number; label?: string } };
 export type SelectionEntry = {
   value: string;

--- a/app/api/core/domain/template/specs/DateRangeProperty.spec.ts
+++ b/app/api/core/domain/template/specs/DateRangeProperty.spec.ts
@@ -111,12 +111,82 @@ describe('DateRangeProperty', () => {
       );
     });
 
+    it('should allow "to" to be null', () => {
+      const dateRange = new DateRangeProperty({ id: 'any_id', label: 'A Title', template: 'any' });
+
+      const assignment = dateRange.createPropertyAssignment({
+        value: [{ value: { from: 1761576489, to: null } }],
+      });
+
+      expect(assignment).toEqual({
+        name: dateRange.name,
+        value: [{ value: { from: 1761576489, to: null } }],
+        type: dateRange.type,
+        isTranslatable: false,
+      });
+    });
+
+    it('should allow "from" to be null', () => {
+      const dateRange = new DateRangeProperty({ id: 'any_id', label: 'A Title', template: 'any' });
+
+      const assignment = dateRange.createPropertyAssignment({
+        value: [{ value: { from: null, to: 1761576489 } }],
+      });
+
+      expect(assignment).toEqual({
+        name: dateRange.name,
+        value: [{ value: { from: null, to: 1761576489 } }],
+        type: dateRange.type,
+        isTranslatable: false,
+      });
+    });
+
+    it('should filter out entries where both "from" and "to" are null', () => {
+      const dateRange = new DateRangeProperty({ id: 'any_id', label: 'A Title', template: 'any' });
+
+      const assignment = dateRange.createPropertyAssignment({
+        value: [{ value: { from: null, to: null } }],
+      });
+
+      expect(assignment).toEqual({
+        name: dateRange.name,
+        value: [],
+        type: dateRange.type,
+        isTranslatable: false,
+      });
+    });
+
     it('should throw if "to" is before "from"', () => {
       const dateRange = new DateRangeProperty({ id: 'any_id', label: 'A Title', template: 'any' });
 
       expect(() =>
         dateRange.createPropertyAssignment({ value: [{ value: { from: 20, to: 10 } }] })
       ).toThrow();
+    });
+
+    it('should not throw when "to" is null even if it would be before "from"', () => {
+      const dateRange = new DateRangeProperty({ id: 'any_id', label: 'A Title', template: 'any' });
+
+      expect(() =>
+        dateRange.createPropertyAssignment({ value: [{ value: { from: 20, to: null } }] })
+      ).not.toThrow();
+    });
+  });
+
+  describe('validatePropertyAssignment()', () => {
+    it('should throw if both "from" and "to" are null (safety net)', () => {
+      const dateRange = new DateRangeProperty({ id: 'any_id', label: 'A Title', template: 'any' });
+
+      expect(() =>
+        dateRange.validatePropertyAssignment({
+          name: dateRange.name,
+          type: dateRange.type,
+          isTranslatable: false,
+          value: [{ value: { from: null, to: null } }],
+        })
+      ).toThrow(
+        '"message": "Date Range Property requires at least one of \\"from\\" or \\"to\\"."'
+      );
     });
   });
 });

--- a/app/api/core/domain/template/specs/MultiDateRangeProperty.spec.ts
+++ b/app/api/core/domain/template/specs/MultiDateRangeProperty.spec.ts
@@ -107,5 +107,102 @@ describe('MultiDateRangeProperty', () => {
         })
       ).toThrow();
     });
+
+    it('should allow "to" to be null', () => {
+      const multiDateRange = new MultiDateRangeProperty({
+        id: 'any_id',
+        label: 'A Title',
+        template: 'any',
+      });
+
+      const assignment = multiDateRange.createPropertyAssignment({
+        value: [{ value: { from: 100, to: null } }, { value: { from: 300, to: 400 } }],
+      });
+
+      expect(assignment).toEqual({
+        name: multiDateRange.name,
+        type: multiDateRange.type,
+        isTranslatable: false,
+        value: [{ value: { from: 100, to: null } }, { value: { from: 300, to: 400 } }],
+      });
+    });
+
+    it('should allow "from" to be null', () => {
+      const multiDateRange = new MultiDateRangeProperty({
+        id: 'any_id',
+        label: 'A Title',
+        template: 'any',
+      });
+
+      const assignment = multiDateRange.createPropertyAssignment({
+        value: [{ value: { from: null, to: 200 } }, { value: { from: 300, to: 400 } }],
+      });
+
+      expect(assignment).toEqual({
+        name: multiDateRange.name,
+        type: multiDateRange.type,
+        isTranslatable: false,
+        value: [{ value: { from: null, to: 200 } }, { value: { from: 300, to: 400 } }],
+      });
+    });
+
+    it('should filter out entries where both "from" and "to" are null', () => {
+      const multiDateRange = new MultiDateRangeProperty({
+        id: 'any_id',
+        label: 'A Title',
+        template: 'any',
+      });
+
+      const assignment = multiDateRange.createPropertyAssignment({
+        value: [
+          { value: { from: 100, to: 200 } },
+          { value: { from: null, to: null } },
+          { value: { from: 300, to: null } },
+          { value: { from: null, to: null } },
+        ],
+      });
+
+      expect(assignment).toEqual({
+        name: multiDateRange.name,
+        type: multiDateRange.type,
+        isTranslatable: false,
+        value: [{ value: { from: 100, to: 200 } }, { value: { from: 300, to: null } }],
+      });
+    });
+
+    it('should not throw when "to" is null even if it would be before "from"', () => {
+      const multiDateRange = new MultiDateRangeProperty({
+        id: 'any_id',
+        label: 'A Title',
+        template: 'any',
+      });
+
+      expect(() =>
+        multiDateRange.createPropertyAssignment({
+          value: [{ value: { from: 300, to: null } }],
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe('validatePropertyAssignment()', () => {
+    it('should throw if both "from" and "to" are null (safety net)', () => {
+      const multiDateRange = new MultiDateRangeProperty({
+        id: 'any_id',
+        label: 'A Title',
+        template: 'any',
+      });
+
+      expect(() =>
+        multiDateRange.validatePropertyAssignment({
+          name: multiDateRange.name,
+          type: multiDateRange.type,
+          isTranslatable: false,
+          value: [{ value: { from: null, to: null } }],
+        })
+      ).toThrow(
+        '"message": "Multi Date Range Property requires at least one of \\"from\\" or \\"to\\"."'
+      );
+    });
   });
 });

--- a/app/api/core/infrastructure/factories/CreateEntityUseCaseFactory.ts
+++ b/app/api/core/infrastructure/factories/CreateEntityUseCaseFactory.ts
@@ -34,7 +34,7 @@ class CreateEntityUseCaseFactory {
     const translationsDS = DefaultTranslationsDataSource(transactionManager);
 
     const propertyAssignmentCreatorServiceStrategy =
-      PropertyAssignmentCreatorServiceStrategy.create({
+      PropertyAssignmentCreatorServiceStrategy.createWithRequired({
         entitiesDS,
         settingsDS,
         thesauriDS,

--- a/app/api/core/infrastructure/factories/UpdateEntityUseCaseFactory.ts
+++ b/app/api/core/infrastructure/factories/UpdateEntityUseCaseFactory.ts
@@ -27,7 +27,7 @@ class UpdateEntityUseCaseFactory {
     const templatesDS = TemplatesDataSourceFactory.default(transactionManager);
 
     const propertyAssignmentCreatorServiceStrategy =
-      PropertyAssignmentCreatorServiceStrategy.create({
+      PropertyAssignmentCreatorServiceStrategy.createWithRequired({
         entitiesDS,
         settingsDS,
         thesauriDS,


### PR DESCRIPTION
## Fix 1 — DateRange null-side validation

- Align v2 domain validation with v1 behaviour: only reject entries where **both** `from` and `to` are null; a null on one side is valid and preserved.
- Widen `DateRangeEntry` type to `{ from: number | null; to: number | null }`.
- `RangeSchema` fields use `z.number().nullable()` (with `required_error` kept so missing keys still throw).
- `superRefine` rejects when both sides are null and only compares `from`/`to` when both are non-null.
- Filter updated to only drop entries where both sides are null, matching v1 sanitization.

## Fix 2 — `validateRequired` is context-driven, not hardcoded

- Removed hardcoded `validateRequired: true` from all `PropertyAssignmentCreatorService` implementations (`Default`, `Select`, `Relationship`, `Image`, `Media`).
- Required validation is now opt-in via `PropertyAssignmentCreatorServiceStrategy.createWithRequired(...)`.
- `CreateEntity` and `UpdateEntity` use cases always call `createWithRequired`, reflecting the fact that both hardcode `validateRequired = true` at the domain level.