### PR TITLE
Prevent client response when client aborts file download

### DIFF
--- a/app/api/common.v2/errors/ClientAbortedRequestError.ts
+++ b/app/api/common.v2/errors/ClientAbortedRequestError.ts
@@ -1,0 +1,8 @@
+import { OperationalError } from './OperationalError.js';
+
+export class ClientAbortedRequestError extends OperationalError {
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ClientAbortedRequestError';
+  }
+}

--- a/app/api/core/infrastructure/express/DownloadFileController.ts
+++ b/app/api/core/infrastructure/express/DownloadFileController.ts
@@ -17,7 +17,7 @@ import { FilesDataSourceFactory } from '../factories/FilesDataSourceFactory.js';
 import { TransactionManagerFactory } from '../factories/TransactionManagerFactory.js';
 import { getConnection } from '../mongodb/common/getConnectionForCurrentTenant.js';
 import { MongoEntityPermissionChecker } from '../mongodb/entity/MongoEntityPermissionChecker.js';
-import { OperationalError } from '#api/common.v2/errors/OperationalError.js';
+import { ClientAbortedRequestError } from '#api/common.v2/errors/ClientAbortedRequestError.js';
 
 const timestampToHTTPDate = (timestamp: number): string => new Date(timestamp).toUTCString();
 
@@ -83,7 +83,7 @@ class DownloadFileController extends AbstractController {
       await pipeline(fileContents.read(), this.response);
     } catch (e) {
       if (e.code === 'ERR_STREAM_PREMATURE_CLOSE' && this.request.aborted) {
-        throw new OperationalError('Client aborted the request', { cause: e });
+        throw new ClientAbortedRequestError('Client aborted file download', { cause: e });
       }
       throw e;
     }

--- a/app/api/core/infrastructure/express/specs/DownloadFileController.spec.ts
+++ b/app/api/core/infrastructure/express/specs/DownloadFileController.spec.ts
@@ -129,7 +129,7 @@ describe('DownloadFileController', () => {
 
   describe('pipeline error handling', () => {
     describe('when stream fails with ERR_STREAM_PREMATURE_CLOSE', () => {
-      it('should throw OperationalError when request was aborted', async () => {
+      it('should throw ClientAbortedRequestError when request was aborted', async () => {
         const error: any = new Error('Premature close');
         error.code = 'ERR_STREAM_PREMATURE_CLOSE';
 

--- a/app/api/core/infrastructure/express/specs/DownloadFileController.spec.ts
+++ b/app/api/core/infrastructure/express/specs/DownloadFileController.spec.ts
@@ -2,7 +2,7 @@ import { TestUtils } from '#api/common.v2/utils/Test.js';
 import { Request, Response } from 'express';
 import { Writable } from 'stream';
 import { tenants } from '#api/tenants/index.js';
-import { OperationalError } from '#api/common.v2/errors/OperationalError.js';
+import { ClientAbortedRequestError } from '#api/common.v2/errors/ClientAbortedRequestError.js';
 import { FileStorage } from '#api/core/application/contracts/FileStorage.js';
 import { FileContents } from '#api/core/domain/files/FileContents.js';
 import { fileDBO } from '#api/core/infrastructure/mongodb/files/schemas/filesTypes.js';
@@ -140,8 +140,7 @@ describe('DownloadFileController', () => {
 
         const promise = sut.handleAsync();
 
-        await expect(promise).rejects.toThrow(OperationalError);
-        await expect(promise).rejects.toThrow('Client aborted the request');
+        await expect(promise).rejects.toThrow(ClientAbortedRequestError);
       });
 
       it('should re-throw original error when request was NOT aborted', async () => {
@@ -156,7 +155,7 @@ describe('DownloadFileController', () => {
         const promise = sut.handleAsync();
 
         await expect(promise).rejects.toThrow('Premature close');
-        await expect(promise).rejects.not.toThrow(OperationalError);
+        await expect(promise).rejects.not.toThrow(ClientAbortedRequestError);
 
         try {
           await promise;
@@ -178,7 +177,7 @@ describe('DownloadFileController', () => {
         const promise = sut.handleAsync();
 
         await expect(promise).rejects.toThrow('File not found');
-        await expect(promise).rejects.not.toThrow(OperationalError);
+        await expect(promise).rejects.not.toThrow(ClientAbortedRequestError);
 
         try {
           await promise;
@@ -198,7 +197,7 @@ describe('DownloadFileController', () => {
         const promise = sut.handleAsync();
 
         await expect(promise).rejects.toThrow('Permission denied');
-        await expect(promise).rejects.not.toThrow(OperationalError);
+        await expect(promise).rejects.not.toThrow(ClientAbortedRequestError);
 
         try {
           await promise;
@@ -217,7 +216,7 @@ describe('DownloadFileController', () => {
         const promise = sut.handleAsync();
 
         await expect(promise).rejects.toThrow('Generic stream error');
-        await expect(promise).rejects.not.toThrow(OperationalError);
+        await expect(promise).rejects.not.toThrow(ClientAbortedRequestError);
       });
     });
 
@@ -234,7 +233,7 @@ describe('DownloadFileController', () => {
         const promise = sut.handleAsync();
 
         await expect(promise).rejects.toThrow('Connection reset');
-        await expect(promise).rejects.not.toThrow(OperationalError);
+        await expect(promise).rejects.not.toThrow(ClientAbortedRequestError);
 
         try {
           await promise;

--- a/app/api/utils/error_handling_middleware.js
+++ b/app/api/utils/error_handling_middleware.js
@@ -37,5 +37,8 @@ export default (error, req, res, next) => {
   if (!(error instanceof ClientAbortedRequestError)) {
     res.status(code);
     res.json({ error: message, ...rest });
+  } else {
+    // ClientAbortedRequestError: delegate to Express default handler
+    return next(error);
   }
 };

--- a/app/api/utils/error_handling_middleware.js
+++ b/app/api/utils/error_handling_middleware.js
@@ -1,36 +1,41 @@
 import { handleError } from './handleError.js';
 import { LoggerFactory } from '#api/core/infrastructure/factories/LoggerFactory.js';
+import { ClientAbortedRequestError } from '#api/common.v2/errors/ClientAbortedRequestError.js';
 
 // eslint-disable-next-line import/no-default-export, consistent-return
 export default (error, req, res, next) => {
   if (res.headersSent) {
-    LoggerFactory.default().debug('Headers already sent when error middleware called', {
-      namespace: 'Error_Middleware',
-      errorType: 'ERR_HTTP_HEADERS_SENT',
+    if (!(error instanceof ClientAbortedRequestError)) {
+      LoggerFactory.default().debug('Headers already sent when error middleware called', {
+        namespace: 'Error_Middleware',
 
-      url: req.url,
-      method: req.method,
-      routePath: req.route?.path,
+        url: req.url,
+        method: req.method,
+        routePath: req.route?.path,
 
-      aborted: req.aborted,
-      statusCodeSent: res.statusCode,
+        aborted: req.aborted,
+        statusCodeSent: res.statusCode,
 
-      errorMessage: error.message,
-      errorCode: error.code,
-      errorName: error.name,
-      errorStack: error.stack,
+        errorMessage: error.message,
+        errorCode: error.code,
+        errorName: error.name,
+        errorStack: error.stack,
 
-      query: JSON.stringify(req.query),
+        query: JSON.stringify(req.query),
 
-      notify: false,
-    });
+        notify: true,
+      });
+    }
 
-    // Pass to Express default error handler (closes connection gracefully)
     return next(error);
   }
 
   const { message, code, ...rest } = handleError(error, { req });
 
-  res.status(code);
-  res.json({ error: message, ...rest });
+  // Don't attempt to send a response for client-aborted requests
+  // since headers may have already been sent during streaming
+  if (!(error instanceof ClientAbortedRequestError)) {
+    res.status(code);
+    res.json({ error: message, ...rest });
+  }
 };

--- a/app/api/utils/error_handling_middleware.js
+++ b/app/api/utils/error_handling_middleware.js
@@ -1,10 +1,36 @@
 import { handleError } from './handleError.js';
+import { LoggerFactory } from '#api/core/infrastructure/factories/LoggerFactory.js';
 
+// eslint-disable-next-line import/no-default-export, consistent-return
 export default (error, req, res, next) => {
+  if (res.headersSent) {
+    LoggerFactory.default().debug('Headers already sent when error middleware called', {
+      namespace: 'Error_Middleware',
+      errorType: 'ERR_HTTP_HEADERS_SENT',
+
+      url: req.url,
+      method: req.method,
+      routePath: req.route?.path,
+
+      aborted: req.aborted,
+      statusCodeSent: res.statusCode,
+
+      errorMessage: error.message,
+      errorCode: error.code,
+      errorName: error.name,
+      errorStack: error.stack,
+
+      query: JSON.stringify(req.query),
+
+      notify: false,
+    });
+
+    // Pass to Express default error handler (closes connection gracefully)
+    return next(error);
+  }
+
   const { message, code, ...rest } = handleError(error, { req });
 
   res.status(code);
   res.json({ error: message, ...rest });
-
-  next();
 };

--- a/app/api/utils/specs/error_handling_middleware.spec.js
+++ b/app/api/utils/specs/error_handling_middleware.spec.js
@@ -1,19 +1,29 @@
 import { appContext } from '#api/utils/AppContext.js';
 import middleware from '../error_handling_middleware.js';
 import { legacyLogger } from '../../log.js';
+import { LoggerFactory } from '#api/core/infrastructure/factories/LoggerFactory.js';
 
 describe('Error handling middleware', () => {
   let next;
   let res;
   let req = {};
+  let mockLogger;
 
   const contextRequestId = '1234';
   beforeEach(() => {
     req = {};
     next = jest.fn();
-    res = { json: jest.fn(), status: jest.fn() };
+    res = { json: jest.fn(), status: jest.fn(), headersSent: false };
+    mockLogger = {
+      error: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      warning: jest.fn(),
+      critical: jest.fn(),
+    };
     jest.spyOn(legacyLogger, 'error').mockImplementation(() => {});
     jest.spyOn(appContext, 'get').mockReturnValue(contextRequestId);
+    jest.spyOn(LoggerFactory, 'default').mockReturnValue(mockLogger);
   });
 
   it('should respond with the error and error code as status', () => {
@@ -27,7 +37,7 @@ describe('Error handling middleware', () => {
       prettyMessage: 'A server side error has occurred',
       requestId: contextRequestId,
     });
-    expect(next).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('should log the url', () => {
@@ -64,5 +74,63 @@ describe('Error handling middleware', () => {
       `requestId: ${contextRequestId} \nquery: ${JSON.stringify(req.query, null, ' ')}\nerror`,
       {}
     );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  describe('when headers are already sent', () => {
+    it('should log comprehensive diagnostic information', () => {
+      const error = {
+        message: 'Cannot set headers after they are sent to the client',
+        code: 'ERR_HTTP_HEADERS_SENT',
+        name: 'Error',
+        stack: 'Error: Cannot set headers...\n    at ...',
+      };
+      req = {
+        url: '/en/library',
+        method: 'GET',
+        route: { path: '/en/:locale' },
+        user: { _id: 'user123', role: 'admin' },
+        aborted: false,
+        headers: { 'user-agent': 'test' },
+        query: { q: 'search' },
+      };
+      res.headersSent = true;
+      res.statusCode = 200;
+
+      middleware(error, req, res, next);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Headers already sent when error middleware called',
+        {
+          namespace: 'Error_Middleware',
+          errorType: 'ERR_HTTP_HEADERS_SENT',
+          url: '/en/library',
+          method: 'GET',
+          routePath: '/en/:locale',
+          aborted: false,
+          statusCodeSent: 200,
+          errorMessage: 'Cannot set headers after they are sent to the client',
+          errorCode: 'ERR_HTTP_HEADERS_SENT',
+          errorName: 'Error',
+          errorStack: 'Error: Cannot set headers...\n    at ...',
+          query: JSON.stringify({ q: 'search' }),
+          notify: false,
+        }
+      );
+      expect(next).toHaveBeenCalledWith(error);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
+    it('should pass error to next when headers already sent', () => {
+      const error = { message: 'error', code: 500 };
+      res.headersSent = true;
+
+      middleware(error, req, res, next);
+
+      expect(next).toHaveBeenCalledWith(error);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/api/utils/specs/error_handling_middleware.spec.js
+++ b/app/api/utils/specs/error_handling_middleware.spec.js
@@ -135,7 +135,7 @@ describe('Error handling middleware', () => {
   });
 
   describe('when error is ClientAbortedRequestError', () => {
-    it('should not send response for ClientAbortedRequestError', () => {
+    it('should not send response for ClientAbortedRequestError and delegate to next', () => {
       const error = new ClientAbortedRequestError('Client aborted the request');
       req = {
         url: '/api/files/download/somefile.pdf',
@@ -147,7 +147,7 @@ describe('Error handling middleware', () => {
 
       expect(res.status).not.toHaveBeenCalled();
       expect(res.json).not.toHaveBeenCalled();
-      expect(next).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(error);
     });
 
     it('should NOT log when ClientAbortedRequestError occurs with headers already sent', () => {

--- a/app/api/utils/specs/error_handling_middleware.spec.js
+++ b/app/api/utils/specs/error_handling_middleware.spec.js
@@ -2,6 +2,7 @@ import { appContext } from '#api/utils/AppContext.js';
 import middleware from '../error_handling_middleware.js';
 import { legacyLogger } from '../../log.js';
 import { LoggerFactory } from '#api/core/infrastructure/factories/LoggerFactory.js';
+import { ClientAbortedRequestError } from '#api/common.v2/errors/ClientAbortedRequestError.js';
 
 describe('Error handling middleware', () => {
   let next;
@@ -103,7 +104,6 @@ describe('Error handling middleware', () => {
         'Headers already sent when error middleware called',
         {
           namespace: 'Error_Middleware',
-          errorType: 'ERR_HTTP_HEADERS_SENT',
           url: '/en/library',
           method: 'GET',
           routePath: '/en/:locale',
@@ -114,7 +114,7 @@ describe('Error handling middleware', () => {
           errorName: 'Error',
           errorStack: 'Error: Cannot set headers...\n    at ...',
           query: JSON.stringify({ q: 'search' }),
-          notify: false,
+          notify: true,
         }
       );
       expect(next).toHaveBeenCalledWith(error);
@@ -128,6 +128,44 @@ describe('Error handling middleware', () => {
 
       middleware(error, req, res, next);
 
+      expect(next).toHaveBeenCalledWith(error);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when error is ClientAbortedRequestError', () => {
+    it('should not send response for ClientAbortedRequestError', () => {
+      const error = new ClientAbortedRequestError('Client aborted the request');
+      req = {
+        url: '/api/files/download/somefile.pdf',
+        method: 'GET',
+        route: { path: '/api/files/download/:filename' },
+      };
+
+      middleware(error, req, res, next);
+
+      expect(res.status).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should NOT log when ClientAbortedRequestError occurs with headers already sent', () => {
+      const error = new ClientAbortedRequestError('Client aborted the request');
+      error.code = 'ERR_STREAM_PREMATURE_CLOSE';
+      req = {
+        url: '/api/files/download/somefile.pdf',
+        method: 'GET',
+        route: { path: '/api/files/download/:filename' },
+        aborted: true,
+        query: {},
+      };
+      res.headersSent = true;
+      res.statusCode = 200;
+
+      middleware(error, req, res, next);
+
+      expect(mockLogger.debug).not.toHaveBeenCalled();
       expect(next).toHaveBeenCalledWith(error);
       expect(res.status).not.toHaveBeenCalled();
       expect(res.json).not.toHaveBeenCalled();


### PR DESCRIPTION
- **Debug ERR_HTTP_HEADERS_SENT error with diagnostic logging**
- **Add ClientAbortedRequestError to prevent headers-already-sent crashes**
