### PR TITLE
Validate url on user login

### DIFF
--- a/app/api/users/specs/__snapshots__/users.spec.js.snap
+++ b/app/api/users/specs/__snapshots__/users.spec.js.snap
@@ -10,7 +10,7 @@ Object {
 }
 `;
 
-exports[`Users login after locking account, it should send user and email with the unlock link 1`] = `
+exports[`Users login after locking account should send user and email with the unlock link 1`] = `
 Array [
   Object {
     "from": "\\"Uwazi instance\\" <no-reply@uwazi.io>",

--- a/app/api/users/specs/users.spec.js
+++ b/app/api/users/specs/users.spec.js
@@ -352,14 +352,35 @@ describe('Users', () => {
       }
     });
 
-    it('after locking account, it should send user and email with the unlock link', async () => {
-      testUser.failedLogins = 5;
-      try {
-        await createUserAndTestLogin('someuser1', 'incorrect');
-        fail('should throw error');
-      } catch (e) {
-        expect(mailer.send.mock.calls[0]).toMatchSnapshot();
-      }
+    describe('after locking account', () => {
+      it('should send user and email with the unlock link', async () => {
+        testUser.failedLogins = 5;
+        try {
+          await createUserAndTestLogin('someuser1', 'incorrect');
+          fail('should throw error');
+        } catch (e) {
+          expect(mailer.send.mock.calls[0]).toMatchSnapshot();
+        }
+      });
+
+      it('should validate domain url before blocking the user', async () => {
+        testUser.failedLogins = 5;
+        try {
+          await usersModel.save(testUser);
+          await users.login(
+            { username: 'someuser1', password: 'incorrect' },
+            'http://host.domain\">http://host.domain</a></p><h1>injected html</h1>'
+          );
+          fail('should throw error');
+        } catch (e) {
+          expect(e.message).toBe('Invalid URL');
+        }
+
+        const dbUser = (await testingEnvironment.db.getAllFrom('users')).find(
+          u => u.username === testUser.username
+        );
+        expect(dbUser.failedLogins).toBe(5);
+      });
     });
 
     it('should prevent login if account is locked when credentials are correct', async () => {

--- a/app/api/users/users.js
+++ b/app/api/users/users.js
@@ -19,6 +19,10 @@ import { PUBLIC_USER_ID } from './publicUser.js';
 
 const MAX_FAILED_LOGIN_ATTEMPTS = 6;
 
+function validateURL(input) {
+  return new URL(input);
+}
+
 function conformRecoverText(options, _settings, domain, key, user) {
   const response = {};
   if (!options.newUser) {
@@ -55,7 +59,8 @@ function conformRecoverText(options, _settings, domain, key, user) {
 }
 
 const sendAccountLockedEmail = async (user, domain) => {
-  const url = `${domain}/unlockaccount/${user.username}/${user.accountUnlockCode}`;
+  const url = new URL(domain);
+  url.pathname += `unlockaccount/${user.username}/${user.accountUnlockCode}`;
   const htmlLink = `<a href="${url}">${url}</a>`;
   const text =
     'Hello,\n\n' +
@@ -263,6 +268,7 @@ export default {
       { username },
       '+password +accountLocked +failedLogins +accountUnlockCode'
     );
+    validateURL(domain);
     const dummy = { password: await encryptPassword('Avoid user enum on login req ms diff') };
     const user = dbuser || dummy;
 


### PR DESCRIPTION
user.login receives a domain (url) in case it needs to send emails to
the user, validating this url prevents potential html injection

fixes #

PR checklist:
- [ ] Update READ.me ?
- [ ] Update API documentation ?

QA checklist:
- [ ] Smoke test the functionality described in the issue
- [ ] Test for side effects
- [ ] UI responsiveness
- [ ] Cross browser testing
- [ ] Code review
