### PR TITLE
Add migration 185 to fix missing fields on thumbnail files

### DIFF
--- a/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/index.ts
+++ b/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/index.ts
@@ -1,0 +1,99 @@
+/* eslint-disable no-await-in-loop */
+/* eslint-disable import/no-default-export */
+import { AnyBulkWriteOperation, Db, ObjectId } from 'mongodb';
+import { ProcessedPdfDocument, ThumbnailDocument } from './types.js';
+
+const BATCH_SIZE = 500;
+
+export default {
+  delta: 185,
+  name: 'fix-missing-fields-on-thumbnails',
+  description:
+    'Fixes thumbnails with missing fields (entity, language, originalname, mimetype) by looking up the corresponding processed PDF. Thumbnails with no matching processed PDF are deleted.',
+  reindex: false,
+
+  async up(db: Db) {
+    process.stdout.write(`${this.name}...\r\n`);
+
+    const cursor = db.collection<ThumbnailDocument>('files').find({
+      type: 'thumbnail',
+      $or: [
+        { entity: { $exists: false } },
+        { language: { $exists: false } },
+        { originalname: { $exists: false } },
+        { mimetype: { $exists: false } },
+      ],
+    });
+
+    let fixed = 0;
+    let deleted = 0;
+    let batch: AnyBulkWriteOperation<ThumbnailDocument>[] = [];
+
+    const flushBatch = async () => {
+      if (!batch.length) return;
+      await db.collection<ThumbnailDocument>('files').bulkWrite(batch, { ordered: false });
+      batch = [];
+    };
+
+    while (await cursor.hasNext()) {
+      const thumbnails: ThumbnailDocument[] = [];
+      while ((await cursor.hasNext()) && thumbnails.length < BATCH_SIZE) {
+        const doc = await cursor.next();
+        if (doc) thumbnails.push(doc);
+      }
+
+      // Derive the processed PDF ObjectIds from the thumbnail filenames
+      const pdfIdByThumbnailId = new Map<string, ObjectId>();
+      const pdfIds: ObjectId[] = [];
+
+      for (const thumbnail of thumbnails) {
+        const pdfIdStr = thumbnail.filename.replace(/\.jpg$/, '');
+        try {
+          const pdfId = new ObjectId(pdfIdStr);
+          pdfIdByThumbnailId.set(thumbnail._id.toHexString(), pdfId);
+          pdfIds.push(pdfId);
+        } catch {
+          // filename does not encode a valid ObjectId — no matching PDF possible
+        }
+      }
+
+      // Fetch all matching processed PDFs in one query
+      const processedPdfs = await db
+        .collection<ProcessedPdfDocument>('files')
+        .find({ _id: { $in: pdfIds }, type: 'document', status: 'ready' })
+        .toArray();
+
+      const pdfMap = new Map<string, ProcessedPdfDocument>(
+        processedPdfs.map(pdf => [pdf._id.toHexString(), pdf])
+      );
+
+      for (const thumbnail of thumbnails) {
+        const pdfId = pdfIdByThumbnailId.get(thumbnail._id.toHexString());
+        const matchingPdf = pdfId ? pdfMap.get(pdfId.toHexString()) : undefined;
+
+        if (!matchingPdf) {
+          batch.push({ deleteOne: { filter: { _id: thumbnail._id } } });
+          deleted += 1;
+        } else {
+          const updateSet: Partial<ThumbnailDocument> = {};
+
+          if (!thumbnail.entity) updateSet.entity = matchingPdf.entity;
+          if (!thumbnail.language) updateSet.language = matchingPdf.language;
+          if (!thumbnail.originalname) updateSet.originalname = thumbnail.filename;
+          if (!thumbnail.mimetype) updateSet.mimetype = 'image/jpeg';
+
+          batch.push({
+            updateOne: { filter: { _id: thumbnail._id }, update: { $set: updateSet } },
+          });
+          fixed += 1;
+        }
+      }
+
+      await flushBatch();
+    }
+
+    process.stdout.write(
+      `fix-missing-fields-on-thumbnails done. Fixed: ${fixed}, Deleted (no matching PDF): ${deleted}.\r\n`
+    );
+  },
+};

--- a/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/specs/185-fix-missing-fields-on-thumbnails.spec.ts
+++ b/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/specs/185-fix-missing-fields-on-thumbnails.spec.ts
@@ -8,6 +8,7 @@ import {
   processedPdfForMissingEntity,
   processedPdfForMissingOriginalnameDoc,
   thumbnailCompleteId,
+  thumbnailInvalidObjectIdId,
   thumbnailMissingAllId,
   thumbnailMissingEntityId,
   thumbnailMissingOriginalnameId,
@@ -86,6 +87,11 @@ describe('migration fix-missing-fields-on-thumbnails', () => {
 
   it('should delete a thumbnail whose filename does not match any processed PDF', async () => {
     const thumbnail = await db!.collection('files').findOne({ _id: thumbnailNoMatchingPdfId });
+    expect(thumbnail).toBeNull();
+  });
+
+  it('should delete a thumbnail whose filename is not a valid ObjectId', async () => {
+    const thumbnail = await db!.collection('files').findOne({ _id: thumbnailInvalidObjectIdId });
     expect(thumbnail).toBeNull();
   });
 });

--- a/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/specs/185-fix-missing-fields-on-thumbnails.spec.ts
+++ b/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/specs/185-fix-missing-fields-on-thumbnails.spec.ts
@@ -1,0 +1,91 @@
+import { Db } from 'mongodb';
+import testingDB from '#api/utils/testing_db.js';
+import migration from '../index.js';
+import { Fixture } from '../types.js';
+import {
+  fixtures,
+  processedPdfForMissingAll,
+  processedPdfForMissingEntity,
+  processedPdfForMissingOriginalnameDoc,
+  thumbnailCompleteId,
+  thumbnailMissingAllId,
+  thumbnailMissingEntityId,
+  thumbnailMissingOriginalnameId,
+  thumbnailNoMatchingPdfId,
+} from './fixtures.js';
+
+let db: Db | null;
+
+const initTest = async (fixture: Fixture) => {
+  await testingDB.setupFixturesAndContext(fixture);
+  db = testingDB.mongodb!;
+  await migration.up(db);
+};
+
+beforeAll(async () => {
+  jest.spyOn(process.stdout, 'write').mockImplementation((_str: string | Uint8Array) => true);
+});
+
+afterAll(async () => {
+  await testingDB.tearDown();
+});
+
+describe('migration fix-missing-fields-on-thumbnails', () => {
+  beforeAll(async () => {
+    await initTest(fixtures);
+  });
+
+  it('should have a delta number', () => {
+    expect(migration.delta).toBe(185);
+  });
+
+  it('should check if a reindex is needed', () => {
+    expect(migration.reindex).toBe(false);
+  });
+
+  it('should not modify a thumbnail that already has all required fields', async () => {
+    const thumbnail = await db!.collection('files').findOne({ _id: thumbnailCompleteId });
+    expect(thumbnail).not.toBeNull();
+    expect(thumbnail!.entity).toBe('entity-complete');
+    expect(thumbnail!.language).toBe('eng');
+    expect(thumbnail!.originalname).toBeDefined();
+    expect(thumbnail!.mimetype).toBe('image/jpeg');
+  });
+
+  it('should fix a thumbnail missing all fields (entity, language, originalname, mimetype)', async () => {
+    const thumbnail = await db!.collection('files').findOne({ _id: thumbnailMissingAllId });
+    expect(thumbnail).not.toBeNull();
+    expect(thumbnail!.entity).toBe(processedPdfForMissingAll.entity);
+    expect(thumbnail!.language).toBe(processedPdfForMissingAll.language);
+    expect(thumbnail!.originalname).toBe(processedPdfForMissingAll._id.toHexString() + '.jpg');
+    expect(thumbnail!.mimetype).toBe('image/jpeg');
+  });
+
+  it('should fix a thumbnail missing only entity', async () => {
+    const thumbnail = await db!.collection('files').findOne({ _id: thumbnailMissingEntityId });
+    expect(thumbnail).not.toBeNull();
+    expect(thumbnail!.entity).toBe(processedPdfForMissingEntity.entity);
+    // Pre-existing fields should be preserved
+    expect(thumbnail!.language).toBe('fra');
+    expect(thumbnail!.mimetype).toBe('image/jpeg');
+  });
+
+  it('should fix a thumbnail missing only originalname', async () => {
+    const thumbnail = await db!
+      .collection('files')
+      .findOne({ _id: thumbnailMissingOriginalnameId });
+    expect(thumbnail).not.toBeNull();
+    expect(thumbnail!.originalname).toBe(
+      processedPdfForMissingOriginalnameDoc._id.toHexString() + '.jpg'
+    );
+    // Pre-existing fields should be preserved
+    expect(thumbnail!.entity).toBe('entity-missing-originalname');
+    expect(thumbnail!.language).toBe('deu');
+    expect(thumbnail!.mimetype).toBe('image/jpeg');
+  });
+
+  it('should delete a thumbnail whose filename does not match any processed PDF', async () => {
+    const thumbnail = await db!.collection('files').findOne({ _id: thumbnailNoMatchingPdfId });
+    expect(thumbnail).toBeNull();
+  });
+});

--- a/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/specs/fixtures.ts
+++ b/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/specs/fixtures.ts
@@ -1,0 +1,145 @@
+import { ObjectId } from 'mongodb';
+import { Fixture } from '../types.js';
+
+// Processed PDFs — their _id is what the thumbnail filename is derived from
+export const processedPdfForCompleteId = new ObjectId();
+export const processedPdfForMissingAllId = new ObjectId();
+export const processedPdfForMissingEntityId = new ObjectId();
+export const processedPdfForMissingOriginalname = new ObjectId();
+
+// Thumbnails
+export const thumbnailCompleteId = new ObjectId();
+export const thumbnailMissingAllId = new ObjectId();
+export const thumbnailMissingEntityId = new ObjectId();
+export const thumbnailMissingOriginalnameId = new ObjectId();
+export const thumbnailNoMatchingPdfId = new ObjectId();
+
+// Processed PDF documents
+export const processedPdfForComplete = {
+  _id: processedPdfForCompleteId,
+  filename: `${processedPdfForCompleteId.toHexString()}.pdf`,
+  originalname: 'complete-doc.pdf',
+  mimetype: 'application/pdf',
+  size: 10000,
+  creationDate: 1000000,
+  type: 'document' as const,
+  status: 'ready' as const,
+  entity: 'entity-complete',
+  language: 'eng',
+  totalPages: 5,
+  generatedToc: false,
+};
+
+export const processedPdfForMissingAll = {
+  _id: processedPdfForMissingAllId,
+  filename: `${processedPdfForMissingAllId.toHexString()}.pdf`,
+  originalname: 'missing-all-doc.pdf',
+  mimetype: 'application/pdf',
+  size: 20000,
+  creationDate: 2000000,
+  type: 'document' as const,
+  status: 'ready' as const,
+  entity: 'entity-missing-all',
+  language: 'spa',
+  totalPages: 3,
+  generatedToc: false,
+};
+
+export const processedPdfForMissingEntity = {
+  _id: processedPdfForMissingEntityId,
+  filename: `${processedPdfForMissingEntityId.toHexString()}.pdf`,
+  originalname: 'missing-entity-doc.pdf',
+  mimetype: 'application/pdf',
+  size: 30000,
+  creationDate: 3000000,
+  type: 'document' as const,
+  status: 'ready' as const,
+  entity: 'entity-missing-entity',
+  language: 'fra',
+  totalPages: 7,
+  generatedToc: false,
+};
+
+export const processedPdfForMissingOriginalnameDoc = {
+  _id: processedPdfForMissingOriginalname,
+  filename: `${processedPdfForMissingOriginalname.toHexString()}.pdf`,
+  originalname: 'missing-originalname-doc.pdf',
+  mimetype: 'application/pdf',
+  size: 40000,
+  creationDate: 4000000,
+  type: 'document' as const,
+  status: 'ready' as const,
+  entity: 'entity-missing-originalname',
+  language: 'deu',
+  totalPages: 2,
+  generatedToc: false,
+};
+
+// Thumbnail documents
+export const thumbnailComplete = {
+  _id: thumbnailCompleteId,
+  filename: `${processedPdfForCompleteId.toHexString()}.jpg`,
+  originalname: `${processedPdfForCompleteId.toHexString()}.jpg`,
+  mimetype: 'image/jpeg',
+  size: 12535,
+  creationDate: 1583767594000,
+  type: 'thumbnail' as const,
+  entity: 'entity-complete',
+  language: 'eng',
+};
+
+// Missing entity, language, originalname, mimetype — matches processedPdfForMissingAll
+export const thumbnailMissingAll = {
+  _id: thumbnailMissingAllId,
+  filename: `${processedPdfForMissingAllId.toHexString()}.jpg`,
+  type: 'thumbnail' as const,
+  size: 12535,
+  creationDate: 1583767594000,
+};
+
+// Only missing entity — matches processedPdfForMissingEntity
+export const thumbnailMissingEntity = {
+  _id: thumbnailMissingEntityId,
+  filename: `${processedPdfForMissingEntityId.toHexString()}.jpg`,
+  originalname: `${processedPdfForMissingEntityId.toHexString()}.jpg`,
+  mimetype: 'image/jpeg',
+  size: 12535,
+  creationDate: 1583767594000,
+  type: 'thumbnail' as const,
+  language: 'fra',
+};
+
+// Only missing originalname — matches processedPdfForMissingOriginalnameDoc
+export const thumbnailMissingOriginalname = {
+  _id: thumbnailMissingOriginalnameId,
+  filename: `${processedPdfForMissingOriginalname.toHexString()}.jpg`,
+  mimetype: 'image/jpeg',
+  size: 12535,
+  creationDate: 1583767594000,
+  type: 'thumbnail' as const,
+  entity: 'entity-missing-originalname',
+  language: 'deu',
+};
+
+// No matching processed PDF — should be deleted
+export const thumbnailNoMatchingPdf = {
+  _id: thumbnailNoMatchingPdfId,
+  filename: `${thumbnailNoMatchingPdfId.toHexString()}.jpg`,
+  type: 'thumbnail' as const,
+  size: 12535,
+  creationDate: 1583767594000,
+};
+
+export const fixtures: Fixture = {
+  files: [
+    processedPdfForComplete,
+    processedPdfForMissingAll,
+    processedPdfForMissingEntity,
+    processedPdfForMissingOriginalnameDoc,
+    thumbnailComplete,
+    thumbnailMissingAll,
+    thumbnailMissingEntity,
+    thumbnailMissingOriginalname,
+    thumbnailNoMatchingPdf,
+  ],
+};

--- a/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/specs/fixtures.ts
+++ b/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/specs/fixtures.ts
@@ -13,6 +13,7 @@ export const thumbnailMissingAllId = new ObjectId();
 export const thumbnailMissingEntityId = new ObjectId();
 export const thumbnailMissingOriginalnameId = new ObjectId();
 export const thumbnailNoMatchingPdfId = new ObjectId();
+export const thumbnailInvalidObjectIdId = new ObjectId();
 
 // Processed PDF documents
 export const processedPdfForComplete = {
@@ -130,6 +131,15 @@ export const thumbnailNoMatchingPdf = {
   creationDate: 1583767594000,
 };
 
+// Filename is not a valid ObjectId — should be deleted
+export const thumbnailInvalidObjectId = {
+  _id: thumbnailInvalidObjectIdId,
+  filename: 'not-a-valid-objectid.jpg',
+  type: 'thumbnail' as const,
+  size: 12535,
+  creationDate: 1583767594000,
+};
+
 export const fixtures: Fixture = {
   files: [
     processedPdfForComplete,
@@ -141,5 +151,6 @@ export const fixtures: Fixture = {
     thumbnailMissingEntity,
     thumbnailMissingOriginalname,
     thumbnailNoMatchingPdf,
+    thumbnailInvalidObjectId,
   ],
 };

--- a/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/types.ts
+++ b/app/api/migrations/migrations/185-fix-missing-fields-on-thumbnails/types.ts
@@ -1,0 +1,40 @@
+import { ObjectId } from 'mongodb';
+
+export interface ThumbnailDocument {
+  _id: ObjectId;
+  filename: string;
+  type: 'thumbnail';
+  entity?: string;
+  language?: string;
+  originalname?: string;
+  mimetype?: string;
+  size?: number;
+  creationDate?: number;
+}
+
+export interface ProcessedPdfDocument {
+  _id: ObjectId;
+  entity: string;
+  language: string;
+  type: 'document';
+  status: 'ready';
+}
+
+interface FileSchema {
+  _id?: ObjectId;
+  filename?: string;
+  originalname?: string;
+  mimetype?: string;
+  size?: number;
+  creationDate?: number;
+  type?: 'document' | 'thumbnail' | 'attachment' | 'custom';
+  entity?: string;
+  language?: string;
+  status?: 'processing' | 'failed' | 'ready';
+  totalPages?: number;
+  generatedToc?: boolean;
+}
+
+export interface Fixture {
+  files: FileSchema[];
+}


### PR DESCRIPTION
Thumbnails missing entity, language, originalname or mimetype are
fixed by looking up the corresponding processed PDF via the thumbnail
filename (<processedPdf._id>.jpg). Thumbnails with no matching
processed PDF are deleted.
